### PR TITLE
[fix bug 870495] Common match rules with checkboxes.

### DIFF
--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -28,8 +28,21 @@ class SnippetAdmin(admin.ModelAdmin):
             'description': 'When will this snippet be available? (Optional)',
             'fields': ('publish_start', 'publish_end'),
         }),
+        ('Products', {
+            'fields': (('on_firefox', 'on_fennec'),)
+        }),
+        ('Product channels', {
+            'description': 'What channels will this snippet be available in?',
+            'fields': (('on_release', 'on_beta', 'on_aurora', 'on_nightly'),)
+        }),
+        ('Startpage Versions', {
+            'fields': (('on_startpage_1', 'on_startpage_2', 'on_startpage_3',
+                        'on_startpage_4'),),
+            'classes': ('collapse',)
+        }),
         ('Client Match Rules', {
             'fields': ('client_match_rules',),
+            'classes': ('collapse',)
         }),
     )
 admin.site.register(models.Snippet, SnippetAdmin)

--- a/snippets/base/managers.py
+++ b/snippets/base/managers.py
@@ -16,3 +16,29 @@ class ClientMatchRuleQuerySet(QuerySet):
 class ClientMatchRuleManager(Manager):
     def get_query_set(self):
         return ClientMatchRuleQuerySet(self.model)
+
+
+class SnippetManager(Manager):
+    def match_client(self, client):
+        from snippets.base.models import (CHANNELS, CLIENT_NAMES,
+                                          STARTPAGE_VERSIONS)
+        filters = {}
+        # Retrieve the first item that starts with an available item. Allows
+        # things like "release-cck-mozilla14" to match "release".
+        client_channel = next((channel for channel in CHANNELS if
+                               client.channel.startswith(channel)), False)
+        if client_channel:
+            filters.update(**{'on_{0}'.format(client_channel):True})
+
+        client_startpage_version = next(
+            (version for version in STARTPAGE_VERSIONS if
+             client.startpage_version.startswith(version)), False)
+        if client_startpage_version:
+            filters.update(
+                **{'on_startpage_{0}'.format(client_startpage_version):True})
+
+        client_name = CLIENT_NAMES.get(client.name, False)
+        if client_name:
+            filters.update(**{'on_{0}'.format(client_name):True})
+
+        return self.filter(**filters)

--- a/snippets/base/migrations/0004_auto__add_field_snippet_on_firefox__add_field_snippet_on_fennec__add_f.py
+++ b/snippets/base/migrations/0004_auto__add_field_snippet_on_firefox__add_field_snippet_on_fennec__add_f.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Snippet.on_firefox'
+        db.add_column('base_snippet', 'on_firefox',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_fennec'
+        db.add_column('base_snippet', 'on_fennec',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_release'
+        db.add_column('base_snippet', 'on_release',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_beta'
+        db.add_column('base_snippet', 'on_beta',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_aurora'
+        db.add_column('base_snippet', 'on_aurora',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_nightly'
+        db.add_column('base_snippet', 'on_nightly',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_startpage_1'
+        db.add_column('base_snippet', 'on_startpage_1',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_startpage_2'
+        db.add_column('base_snippet', 'on_startpage_2',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_startpage_3'
+        db.add_column('base_snippet', 'on_startpage_3',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_startpage_4'
+        db.add_column('base_snippet', 'on_startpage_4',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+        # Changing field 'ClientMatchRule.appbuildid'
+        db.alter_column('base_clientmatchrule', 'appbuildid', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.locale'
+        db.alter_column('base_clientmatchrule', 'locale', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.distribution_version'
+        db.alter_column('base_clientmatchrule', 'distribution_version', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.startpage_version'
+        db.alter_column('base_clientmatchrule', 'startpage_version', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.os_version'
+        db.alter_column('base_clientmatchrule', 'os_version', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.version'
+        db.alter_column('base_clientmatchrule', 'version', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.distribution'
+        db.alter_column('base_clientmatchrule', 'distribution', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.build_target'
+        db.alter_column('base_clientmatchrule', 'build_target', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.channel'
+        db.alter_column('base_clientmatchrule', 'channel', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.name'
+        db.alter_column('base_clientmatchrule', 'name', self.gf('snippets.base.models.RegexField')(max_length=64))
+
+    def backwards(self, orm):
+        # Deleting field 'Snippet.on_firefox'
+        db.delete_column('base_snippet', 'on_firefox')
+
+        # Deleting field 'Snippet.on_fennec'
+        db.delete_column('base_snippet', 'on_fennec')
+
+        # Deleting field 'Snippet.on_release'
+        db.delete_column('base_snippet', 'on_release')
+
+        # Deleting field 'Snippet.on_beta'
+        db.delete_column('base_snippet', 'on_beta')
+
+        # Deleting field 'Snippet.on_aurora'
+        db.delete_column('base_snippet', 'on_aurora')
+
+        # Deleting field 'Snippet.on_nightly'
+        db.delete_column('base_snippet', 'on_nightly')
+
+        # Deleting field 'Snippet.on_startpage_1'
+        db.delete_column('base_snippet', 'on_startpage_1')
+
+        # Deleting field 'Snippet.on_startpage_2'
+        db.delete_column('base_snippet', 'on_startpage_2')
+
+        # Deleting field 'Snippet.on_startpage_3'
+        db.delete_column('base_snippet', 'on_startpage_3')
+
+        # Deleting field 'Snippet.on_startpage_4'
+        db.delete_column('base_snippet', 'on_startpage_4')
+
+
+        # Changing field 'ClientMatchRule.appbuildid'
+        db.alter_column('base_clientmatchrule', 'appbuildid', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.locale'
+        db.alter_column('base_clientmatchrule', 'locale', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.distribution_version'
+        db.alter_column('base_clientmatchrule', 'distribution_version', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.startpage_version'
+        db.alter_column('base_clientmatchrule', 'startpage_version', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.os_version'
+        db.alter_column('base_clientmatchrule', 'os_version', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.version'
+        db.alter_column('base_clientmatchrule', 'version', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.distribution'
+        db.alter_column('base_clientmatchrule', 'distribution', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.build_target'
+        db.alter_column('base_clientmatchrule', 'build_target', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.channel'
+        db.alter_column('base_clientmatchrule', 'channel', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+        # Changing field 'ClientMatchRule.name'
+        db.alter_column('base_clientmatchrule', 'name', self.gf('django.db.models.fields.CharField')(max_length=64))
+
+    models = {
+        'base.clientmatchrule': {
+            'Meta': {'object_name': 'ClientMatchRule'},
+            'appbuildid': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'build_target': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'channel': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'distribution': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'distribution_version': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_exclusion': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'locale': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'os_version': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'startpage_version': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'version': ('snippets.base.models.RegexField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'base.snippet': {
+            'Meta': {'object_name': 'Snippet'},
+            'client_match_rules': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['base.ClientMatchRule']", 'symmetrical': 'False', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            'disabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'on_aurora': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_beta': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_fennec': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_firefox': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_nightly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_release': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_1': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_startpage_2': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_3': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_4': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'publish_end': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'publish_start': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['base.SnippetTemplate']"})
+        },
+        'base.snippettemplate': {
+            'Meta': {'object_name': 'SnippetTemplate'},
+            'code': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'base.snippettemplatevariable': {
+            'Meta': {'object_name': 'SnippetTemplateVariable'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variable_set'", 'to': "orm['base.SnippetTemplate']"}),
+            'type': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['base']

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -8,8 +8,12 @@ from django.db import models
 from jingo import env
 from jinja2 import Markup
 
-from snippets.base.managers import ClientMatchRuleManager
+from snippets.base.managers import ClientMatchRuleManager, SnippetManager
 
+
+CHANNELS = ('release', 'beta', 'aurora', 'nightly')
+STARTPAGE_VERSIONS = ('1', '2', '3', '4')
+CLIENT_NAMES = {'Firefox': 'firefox', 'fennec': 'fennec'}
 
 # NamedTuple that represents a user's client program.
 Client = namedtuple('Client', (
@@ -135,11 +139,26 @@ class Snippet(models.Model):
     publish_start = models.DateTimeField(blank=True, null=True)
     publish_end = models.DateTimeField(blank=True, null=True)
 
+    on_firefox = models.BooleanField(default=True, verbose_name='Firefox')
+    on_fennec = models.BooleanField(default=False, verbose_name='Fennec')
+
+    on_release = models.BooleanField(default=True, verbose_name='Release')
+    on_beta = models.BooleanField(default=False, verbose_name='Beta')
+    on_aurora = models.BooleanField(default=False, verbose_name='Aurora')
+    on_nightly = models.BooleanField(default=False, verbose_name='Nightly')
+
+    on_startpage_1 = models.BooleanField(default=False, verbose_name='Version 1')
+    on_startpage_2 = models.BooleanField(default=True, verbose_name='Version 2')
+    on_startpage_3 = models.BooleanField(default=True, verbose_name='Version 3')
+    on_startpage_4 = models.BooleanField(default=True, verbose_name='Version 4')
+
     client_match_rules = models.ManyToManyField(
         ClientMatchRule, blank=True, verbose_name='Client Match Rules')
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
+
+    objects = SnippetManager()
 
     def render(self):
         data = json.loads(self.data)
@@ -154,3 +173,7 @@ class Snippet(models.Model):
 
     def __unicode__(self):
         return self.name
+
+
+from south.modelsinspector import add_introspection_rules
+add_introspection_rules([], ["^snippets\.base\.models\.RegexField"])

--- a/snippets/base/tests/test_managers.py
+++ b/snippets/base/tests/test_managers.py
@@ -1,7 +1,8 @@
 from mock import patch
 from nose.tools import eq_
 
-from snippets.base.models import ClientMatchRule
+from snippets.base.managers import SnippetManager
+from snippets.base.models import Client, ClientMatchRule, Snippet
 from snippets.base.tests import ClientMatchRuleFactory, TestCase
 
 
@@ -23,3 +24,43 @@ class ClientMatchRuleQuerySetTests(TestCase):
         passed, failed = self.manager.all().evaluate('asdf')
         eq_([rule1_pass, rule2_pass, rule4_pass], passed)
         eq_([rule3_fail, rule5_fail], failed)
+
+class SnippetManagerTests(TestCase):
+    def _assert_client_passes_filters(self, client_attrs, filters):
+        params = {'startpage_version': '4',
+                  'name': 'Firefox',
+                  'version': '23.0a1',
+                  'appbuildid': '20130510041606',
+                  'build_target': 'Darwin_Universal-gcc3',
+                  'locale': 'en-US',
+                  'channel': 'release',
+                  'os_version': 'Darwin 10.8.0',
+                  'distribution': 'default',
+                  'distribution_version': 'default_version'}
+        params.update(client_attrs)
+        client = Client(**params)
+
+        with patch.object(SnippetManager, 'filter') as mock_filter:
+            Snippet.objects.match_client(client)
+            mock_filter.assert_called_with(**filters)
+
+    def test_match_client(self):
+        params = {}
+        filters = {'on_startpage_4': True, 'on_release':True,
+                   'on_firefox': True}
+        self._assert_client_passes_filters(params, filters)
+
+    def test_match_client_not_matching_channel(self):
+        params = {'channel': 'phantom'}
+        filters = {'on_startpage_4': True, 'on_firefox': True}
+        self._assert_client_passes_filters(params, filters)
+
+    def test_match_client_not_matching_startpage(self):
+        params = {'startpage_version': '0'}
+        filters = {'on_release': True, 'on_firefox': True}
+        self._assert_client_passes_filters(params, filters)
+
+    def test_match_client_not_matching_name(self):
+        params = {'name': 'unicorn'}
+        filters = {'on_startpage_4': True, 'on_release': True}
+        self._assert_client_passes_filters(params, filters)

--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -1,37 +1,64 @@
 from mock import patch
 from nose.tools import eq_, ok_
 
+import snippets.base.models
+from snippets.base.models import ClientMatchRule
 from snippets.base.tests import (ClientMatchRuleFactory, SnippetFactory,
                                  TestCase)
 
+snippets.base.models.CHANNELS = ('release', 'beta', 'aurora', 'nightly')
+snippets.base.models.STARTPAGE_VERSIONS = ('1', '2', '3', '4')
+snippets.base.models.CLIENT_NAMES = {'Firefox': 'firefox', 'fennec': 'fennec'}
+
 
 class FetchSnippetsTests(TestCase):
-    @patch('snippets.base.views.ClientMatchRule')
-    def test_basic(self, ClientMatchRule):
-        failrule1 = ClientMatchRuleFactory.create()
-        failrule2 = ClientMatchRuleFactory.create()
-        passrule1 = ClientMatchRuleFactory.create()
-        passrule2 = ClientMatchRuleFactory.create()
+    @patch('snippets.base.views.ClientMatchRule', wraps=ClientMatchRule)
+    def test_base(self, ClientMatchRuleMock):
+        client_match_rule_pass = ClientMatchRuleFactory(
+            name='Firefox', channel='nightly', startpage_version='4')
+        client_match_rule_fail = ClientMatchRuleFactory(
+            name='Firefox', channel='release', startpage_version='4')
 
-        evaluate = ClientMatchRule.objects.all.return_value.evaluate
-        evaluate.return_value = (
-            [passrule1, passrule2], [failrule1, failrule2]
-        )
+        snippet_pass_1 = SnippetFactory.create(on_nightly=True)
+        snippet_pass_2 = SnippetFactory.create(
+            on_nightly=True, client_match_rules=[client_match_rule_pass])
 
-        snippet_pass = SnippetFactory.create(client_match_rules=[passrule1])
-        snippet_fail = SnippetFactory.create(client_match_rules=[failrule1])
-        snippet_passfail = SnippetFactory.create(
-            client_match_rules=[passrule2, failrule2]
-        )
+        snippet_fail_1 = SnippetFactory.create(on_nightly=False),
+        snippet_fail_2 = SnippetFactory.create(
+            on_nightly=False, client_match_rules=[client_match_rule_pass])
+        snippet_fail_2 = SnippetFactory.create(
+            on_nightly=False, client_match_rules=[client_match_rule_fail])
+        snippet_fail_3 = SnippetFactory.create(
+            on_nightly=True, client_match_rules=[client_match_rule_fail])
+        snippet_fail_4 = SnippetFactory.create(
+            on_nightly=True, client_match_rules=[client_match_rule_fail,
+                                                 client_match_rule_pass])
+
+        snippets_ok = [snippet_pass_1, snippet_pass_2]
+        snippets_fail = [snippet_fail_1, snippet_fail_2, snippet_fail_3,
+                         snippet_fail_4]
+        snippets_pass_match_client = (snippets_ok + 
+                                      [snippet_fail_3, snippet_fail_4])
 
         params = ('4', 'Firefox', '23.0a1', '20130510041606',
                   'Darwin_Universal-gcc3', 'en-US', 'nightly',
                   'Darwin%2010.8.0', 'default', 'default_version')
         response = self.client.get('/{0}/'.format('/'.join(params)))
 
-        ok_(snippet_pass in response.context['snippets'])
-        ok_(snippet_fail not in response.context['snippets'])
-        ok_(snippet_passfail not in response.context['snippets'])
+        eq_(set(snippets_ok), set(response.context['snippets']))
+        call_args = (ClientMatchRuleMock.objects
+                     .filter.call_args[1]['snippet__in'])
+        eq_(set(snippets_pass_match_client), set(call_args))
+        
+    @patch('snippets.base.views.ClientMatchRule.objects')
+    def test_client_construction(self, mock_objects):
+        evaluate = mock_objects.filter.return_value.evaluate
+        evaluate.return_value = ([], [])
+
+        params = ('4', 'Firefox', '23.0a1', '20130510041606',
+                  'Darwin_Universal-gcc3', 'en-US', 'nightly',
+                  'Darwin%2010.8.0', 'default', 'default_version')
+        self.client.get('/{0}/'.format('/'.join(params)))
 
         # Test that the client was constructed correctly.
         client = evaluate.call_args[0][0]

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -20,10 +20,13 @@ def index(request):
 def fetch_snippets(request, **kwargs):
     client = Client(**kwargs)
 
-    passed_rules, failed_rules = ClientMatchRule.objects.all().evaluate(client)
-    matching_snippets = Snippet.objects.exclude(
-        client_match_rules__in=failed_rules
-    )
+    matching_snippets = Snippet.objects.match_client(client)
+    passed_rules, failed_rules = (ClientMatchRule.objects
+                                  .filter(snippet__in=matching_snippets)
+                                  .evaluate(client))
+
+    matching_snippets = (matching_snippets
+                         .exclude(client_match_rules__in=failed_rules))
 
     return render(request, 'base/fetch_snippets.html', {
         'snippets': matching_snippets,


### PR DESCRIPTION
In the current snippets service, I noticed that `client.name` is `Firefox` with a capital `F` or `fennec` with a small `f`. Is are a spec on how we receive client data? Should we `lower()` values when we build `Client()`?

@osmose r?
