### PR TITLE
Use POST instead of GET for transmitting snippet preview arguments.

### DIFF
--- a/snippets/base/static/js/templateDataWidget.js
+++ b/snippets/base/static/js/templateDataWidget.js
@@ -190,24 +190,29 @@
      */
     function SnippetPreview(elem, dataWidget) {
         var self = this;
-        this.$container = $(elem);
         this.dataWidget = dataWidget;
-        this.$iframe = $('<iframe class="snippet-preview"></iframe>');
-        this.$container.append(this.$iframe);
+
+        this.$container = $(elem);
+        this.$container.html(nj.render('snippetPreview.html', {
+            preview_url: this.$container.data('previewUrl')
+        }));
+
+        this.$form = this.$container.find('form');
+        this.$dataInput = this.$form.find('input[name="data"]');
+        this.$templateIdInput = this.$form.find('input[name="template_id"]');
 
         dataWidget.onDataChange(function() {
             self.onDataChange();
         });
+        self.onDataChange(); // Trigger initial preview.
     }
 
     SnippetPreview.prototype = {
         onDataChange: function() {
-            var previewUrl = this.$container.data('previewUrl');
-            var args = $.param({
-                data: JSON.stringify(this.dataWidget.generateData()),
-                template_id: this.dataWidget.getTemplateId()
-            });
-            this.$iframe.attr('src', previewUrl + '?' + args);
+            var data = JSON.stringify(this.dataWidget.generateData());
+            this.$dataInput.val(data);
+            this.$templateIdInput.val(this.dataWidget.getTemplateId());
+            this.$form.submit();
         }
     };
 

--- a/snippets/base/static/templates/snippetPreview.html
+++ b/snippets/base/static/templates/snippetPreview.html
@@ -1,0 +1,5 @@
+<iframe name="snippet-preview" class="snippet-preview"></iframe>
+<form target="snippet-preview" method="post" action="{{ preview_url }}">
+  <input type="text" name="data">
+  <input type="text" name="template_id">
+</form>

--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -136,7 +136,7 @@ class PreviewSnippetTests(TestCase):
         self.client.login(username='admin', password='asdf')
 
     def _preview_snippet(self, **kwargs):
-        return self.client.get(reverse('base.preview'), kwargs)
+        return self.client.post(reverse('base.preview'), kwargs)
 
     def test_invalid_template(self):
         """If template_id is missing or invalid, return a 400 Bad Request."""

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -8,6 +8,7 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.http import HttpResponseBadRequest
 from django.shortcuts import render
 from django.views.decorators.cache import cache_control
+from django.views.decorators.csrf import csrf_exempt
 
 from commonware.response.decorators import xframe_allow
 
@@ -88,15 +89,16 @@ PREVIEW_CLIENT = Client('4', 'Firefox', '24.0', 'default', 'default', 'en-US',
 
 
 @xframe_allow
+@csrf_exempt
 @permission_required('base.change_snippet')
 def preview_snippet(request):
     """
-    Build a snippet using info from the GET parameters, and preview that
+    Build a snippet using info from the POST parameters, and preview that
     snippet on a mock about:home page.
     """
-    template_id = request.GET.get('template_id', None)
+    template_id = request.POST.get('template_id', None)
     template = get_object_or_none(SnippetTemplate, id=template_id)
-    data = request.GET.get('data', None)
+    data = request.POST.get('data', None)
 
     # Validate that data is JSON.
     try:


### PR DESCRIPTION
For large snippets, the URLs used by the snippet preview iframe were
so large that they caused errors on the server. This attempts to avoid
this by using POST to transmit the data instead of GET.
