### PR TITLE
Fix bug 892292: No middleware for fetch_snippets, fix cache headers.

### DIFF
--- a/snippets/base/middleware.py
+++ b/snippets/base/middleware.py
@@ -1,0 +1,20 @@
+from django.core.urlresolvers import resolve
+
+from snippets.base.views import fetch_snippets
+
+
+class FetchSnippetsMiddleware(object):
+    """
+    If the incoming request is for the fetch_snippets view, execute the view
+    and return it before other middleware can run.
+
+    fetch_snippets is a very very basic view that doesn't need any of the
+    middleware that the rest of the site needs, such as the session or csrf
+    middlewares. To avoid unintended issues (such as headers we don't want
+    being added to the response) this middleware detects requests to that view
+    and executes the view early, bypassing the rest of the middleware.
+    """
+    def process_request(self, request):
+        result = resolve(request.path)
+        if result.func == fetch_snippets:
+            return fetch_snippets(request, *result.args, **result.kwargs)

--- a/snippets/base/tests/test_middleware.py
+++ b/snippets/base/tests/test_middleware.py
@@ -1,0 +1,40 @@
+from mock import Mock, patch
+from nose.tools import eq_
+
+from snippets.base.middleware import FetchSnippetsMiddleware
+from snippets.base.tests import TestCase
+
+
+class FetchSnippetsMiddlewareTests(TestCase):
+    def setUp(self):
+        self.middleware = FetchSnippetsMiddleware()
+
+    @patch('snippets.base.middleware.resolve')
+    @patch('snippets.base.middleware.fetch_snippets')
+    def test_resolve_match(self, fetch_snippets, resolve):
+        """
+        If resolve returns a match to the fetch_snippets view, return the
+        result of the view.
+        """
+        request = Mock()
+        result = resolve.return_value
+        result.func = fetch_snippets
+        result.args = (1, 'asdf')
+        result.kwargs = {'blah': 5}
+
+        eq_(self.middleware.process_request(request),
+            fetch_snippets.return_value)
+        fetch_snippets.assert_called_with(request, 1, 'asdf', blah=5)
+
+    @patch('snippets.base.middleware.resolve')
+    @patch('snippets.base.middleware.fetch_snippets')
+    def test_resolve_no_match(self, fetch_snippets, resolve):
+        """
+        If resolve doesn't return a match to the fetch_snippets view, return
+        None.
+        """
+        request = Mock()
+        result = resolve.return_value
+        result.func = lambda request: 'asdf'
+
+        eq_(self.middleware.process_request(request), None)

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
+from django.utils.functional import lazy
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
 
@@ -20,7 +21,8 @@ from snippets.base.models import (Client, ClientMatchRule, Snippet,
 from snippets.base.util import get_object_or_none
 
 
-HTTP_MAX_AGE = getattr(settings, 'SNIPPET_HTTP_MAX_AGE', 1)
+_http_max_age = lambda: getattr(settings, 'SNIPPET_HTTP_MAX_AGE', 90)
+HTTP_MAX_AGE = lazy(_http_max_age, str)()
 SNIPPETS_PER_PAGE = 50
 
 

--- a/snippets/settings/base.py
+++ b/snippets/settings/base.py
@@ -61,6 +61,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'snippets.base.middleware.FetchSnippetsMiddleware',
     'multidb.middleware.PinningRouterMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -68,8 +69,6 @@ MIDDLEWARE_CLASSES = (
     'session_csrf.CsrfMiddleware',  # Must be after auth middleware.
     'django.contrib.messages.middleware.MessageMiddleware',
     'commonware.middleware.FrameOptionsHeader',
-    'mobility.middleware.DetectMobileMiddleware',
-    'mobility.middleware.XMobileMiddleware',
 )
 
 DATABASE_ROUTERS = ()

--- a/snippets/settings/local.py-dist
+++ b/snippets/settings/local.py-dist
@@ -75,4 +75,4 @@ ENGAGE_ROBOTS = True
 #}
 
 # Snippets-specific caching
-SNIPPET_HTTP_MAX_AGE = 75  # Time to cache HTTP responses for snippets.
+SNIPPET_HTTP_MAX_AGE = 90  # Time to cache HTTP responses for snippets.


### PR DESCRIPTION
Since fetch_snippets doesn't need any middleware to run for it to 
fetch snippets for the user, this adds a middleware that bypasses all
other middleware for that view only. This avoids an issue with Vary
headers being added to that view's response, as well as an unnecessary 
database query.

This also sets the default max-age for the view at 90 seconds instead
of 1, and adds a test to ensure the right cache headers are being set
for that view.
