### PR TITLE
Include `snippet_id` in template context for snippet templates.

### DIFF
--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -129,7 +129,7 @@ class SnippetTemplateVariableInline(admin.TabularInline):
     fields = ('name', 'type',)
 
 
-RESERVED_VARIABLES = ('_',)
+RESERVED_VARIABLES = ('_', 'snippet_id')
 
 
 class SnippetTemplateAdmin(BaseModelAdmin):

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -74,6 +74,7 @@ class SnippetTemplate(CachingMixin, models.Model):
     cached_objects = CachingManager()
 
     def render(self, ctx):
+        ctx.setdefault('snippet_id', 0)
         return env.from_string(self.code).render(ctx)
 
     def __unicode__(self):
@@ -189,6 +190,8 @@ class Snippet(CachingMixin, models.Model):
 
     def render(self):
         data = json.loads(self.data)
+        if self.id:
+            data.setdefault('snippet_id', self.id)
 
         # Use a list for attrs to make the output order predictable.
         attrs = [('data-snippet-id', self.id)]


### PR DESCRIPTION
This enables snippet code to include unique IDs in things like element
IDs, making it easier to have snippet templates only affect their 
individual snippets and not other snippets using the same template.

Part of the work for bug 926634.
