### PR TITLE
Add smalltext template variable type.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -88,7 +88,8 @@ class SnippetTemplateVariable(CachingMixin, models.Model):
     """
     TEXT = 0
     IMAGE = 1
-    TYPE_CHOICES = ((TEXT, 'Text'), (IMAGE, 'Image'))
+    SMALLTEXT = 2
+    TYPE_CHOICES = ((TEXT, 'Text'), (IMAGE, 'Image'), (SMALLTEXT, 'Small Text'))
 
     template = models.ForeignKey(SnippetTemplate, related_name='variable_set')
     name = models.CharField(max_length=255)

--- a/snippets/base/static/js/templateDataWidget.js
+++ b/snippets/base/static/js/templateDataWidget.js
@@ -4,7 +4,8 @@
 
     var VARIABLE_TYPES = {
         text: 0,
-        image: 1
+        image: 1,
+        smalltext: 2
     };
 
     // Setup Nunjucks
@@ -90,6 +91,10 @@
             this.$container.on('input', 'textarea', function() {
                 self.triggerDataChange();
             });
+
+            this.$container.on('input', 'input', function() {
+                self.triggerDataChange();
+            });
         },
 
         /**
@@ -166,6 +171,9 @@
                         break;
                     case VARIABLE_TYPES.image:
                         data[variable] = $item.find('img').attr('src');
+                        break;
+                    case VARIABLE_TYPES.smalltext:
+                        data[variable] = $item.find('input').val();
                         break;
                 }
             });

--- a/snippets/base/static/templates/snippetDataWidget.html
+++ b/snippets/base/static/templates/snippetDataWidget.html
@@ -13,6 +13,9 @@
         {% elif variable.type == types.image %}
           <input type="file" class="image-input">
           <img src="{{ originalData[variable.name] }}">
+        {% elif variable.type == types.smalltext %}
+          <input size="100" value="{{ originalData[variable.name] }}"><br/>
+          <small>HTML is allowed.</small>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
Smalltext template variable displays an 'input' element instead of a
textbox, which is more appropriate for things like URLs or Labels.
