### PR TITLE
Disable New Relic monitoring on non-fetch_snippets views.

### DIFF
--- a/snippets/base/middleware.py
+++ b/snippets/base/middleware.py
@@ -13,8 +13,20 @@ class FetchSnippetsMiddleware(object):
     middlewares. To avoid unintended issues (such as headers we don't want
     being added to the response) this middleware detects requests to that view
     and executes the view early, bypassing the rest of the middleware.
+
+    Also disables New Relic's apdex for views that aren't the
+    fetch_snippets, as we only really care about the apdex for
+    fetch_snippets.
     """
     def process_request(self, request):
         result = resolve(request.path)
         if result.func == fetch_snippets:
             return fetch_snippets(request, *result.args, **result.kwargs)
+        else:
+            # Not fetch_snippets? Then no New Relic for you!
+            try:
+                import newrelic.agent
+            except ImportError:
+                pass
+            else:
+                newrelic.agent.suppress_apdex_metric()


### PR DESCRIPTION
New Relic doesn't allow us to set different thresholds for different
pages across the site, so in order to get valuable metrics on the main
view for snippets, fetch_snippets, we need to disable New Relic for the
admin interface and public snippets views, which don't need as close
monitoring.
