### PR TITLE
Do not match snippets that have locales if client locale is invalid.

### DIFF
--- a/snippets/base/managers.py
+++ b/snippets/base/managers.py
@@ -49,5 +49,9 @@ class SnippetManager(CachingManager):
         locales = filter(client.locale.lower().startswith, LANGUAGE_VALUES)
         if locales:
             filters.update(locale_set__locale__in=locales)
+        else:
+            # If the locale is invalid, only match snippets with no
+            # locales specified.
+            filters.update(locale_set__isnull=True)
 
         return self.filter(**filters).distinct()

--- a/snippets/base/tests/test_managers.py
+++ b/snippets/base/tests/test_managers.py
@@ -99,7 +99,8 @@ class SnippetManagerTests(TestCase):
         filters = {
             'on_startpage_4': True,
             'on_release': True,
-            'on_firefox': True
+            'on_firefox': True,
+            'locale_set__isnull': True,
         }
         self._assert_client_passes_filters(params, filters)
 


### PR DESCRIPTION
Fixes a bug where invalid locales are matching tons of snippets that
they shouldn't be receiving.

See <a href="https://snippets.mozilla.com/3/Firefox/15.0.1/20120907230839/Linux_x86-gcc3/qcv/release/Linux 2.6.32-43-generic (GTK 2.20.1)/canonical/1.0/">this link</a> for an example of the bug happening on production.
