### PR TITLE
JSON Snippets

### DIFF
--- a/snippets/base/cron.py
+++ b/snippets/base/cron.py
@@ -80,8 +80,6 @@ def import_v1_data(filename):
                 'on_startpage_2': True,
                 'on_startpage_3': True,
                 'on_startpage_4': True,
-                'on_firefox': True,
-                'on_fennec': True
                 })
 
             # Generate a unique name if needed.

--- a/snippets/base/encoders.py
+++ b/snippets/base/encoders.py
@@ -1,0 +1,14 @@
+import json
+
+from snippets.base.models import JSONSnippet
+
+
+class SnippetEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, JSONSnippet):
+            return {'id': obj.id,
+                    'text': obj.text,
+                    'icon': obj.icon,
+                    'url': obj.url,
+                    'target_geo': obj.country.upper()}
+        return super(SnippetEncoder, self).default(obj)

--- a/snippets/base/managers.py
+++ b/snippets/base/managers.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from django.db.models import get_model
+
 from caching.base import CachingManager, CachingQuerySet
 
 from snippets.base import LANGUAGE_VALUES
@@ -20,10 +24,24 @@ class ClientMatchRuleManager(CachingManager):
         return ClientMatchRuleQuerySet(self.model)
 
 
-class SnippetManager(CachingManager):
+class SnippetQuerySet(CachingQuerySet):
+    def filter_by_available(self):
+        """Datetime filtering of snippets.
+
+        Filter by date in python to avoid caching based on the passing
+        of time.
+        """
+        now = datetime.utcnow()
+        matching_snippets = [
+            snippet for snippet in self if
+            (not snippet.publish_start or snippet.publish_start <= now) and
+            (not snippet.publish_end or snippet.publish_end >= now)
+        ]
+        return matching_snippets
+
     def match_client(self, client):
         from snippets.base.models import (
-            CHANNELS, CLIENT_NAMES, STARTPAGE_VERSIONS)
+            CHANNELS, FENNEC_STARTPAGE_VERSIONS, FIREFOX_STARTPAGE_VERSIONS)
 
         filters = {}
 
@@ -34,16 +52,14 @@ class SnippetManager(CachingManager):
             filters.update(**{'on_{0}'.format(client_channel): True})
 
         # Same matching for the startpage version.
+        STARTPAGE_VERSIONS = FIREFOX_STARTPAGE_VERSIONS
+        if client.name.lower() == 'fennec':
+            STARTPAGE_VERSIONS = FENNEC_STARTPAGE_VERSIONS
         startpage_version = first(STARTPAGE_VERSIONS,
                                   client.startpage_version.startswith)
         if startpage_version:
             filters.update(
                 **{'on_startpage_{0}'.format(startpage_version): True})
-
-        # Only filter the client name here if it matches our whitelist.
-        client_name = CLIENT_NAMES.get(client.name, False)
-        if client_name:
-            filters.update(**{'on_{0}'.format(client_name): True})
 
         # Only filter by locale if they pass a valid locale.
         locales = filter(client.locale.lower().startswith, LANGUAGE_VALUES)
@@ -54,4 +70,21 @@ class SnippetManager(CachingManager):
             # locales specified.
             filters.update(locale_set__isnull=True)
 
-        return self.filter(**filters).distinct()
+        snippets = self.filter(**filters).distinct()
+
+        # Filter based on ClientMatchRules
+        ClientMatchRule = get_model('base', 'ClientMatchRule')
+        passed_rules, failed_rules = (ClientMatchRule.cached_objects
+                                      .filter(snippet__in=snippets)
+                                      .distinct()
+                                      .evaluate(client))
+
+        return snippets.exclude(client_match_rules__in=failed_rules)
+
+
+class SnippetManager(CachingManager):
+    def get_query_set(self):
+        return SnippetQuerySet(self.model)
+
+    def match_client(self, client):
+        return self.get_query_set().match_client(client)

--- a/snippets/base/middleware.py
+++ b/snippets/base/middleware.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import resolve
 
-from snippets.base.views import fetch_snippets
+from snippets.base.views import fetch_json_snippets, fetch_snippets
 
 
 class FetchSnippetsMiddleware(object):
@@ -16,5 +16,5 @@ class FetchSnippetsMiddleware(object):
     """
     def process_request(self, request):
         result = resolve(request.path)
-        if result.func == fetch_snippets:
-            return fetch_snippets(request, *result.args, **result.kwargs)
+        if result.func in (fetch_snippets, fetch_json_snippets):
+            return result.func(request, *result.args, **result.kwargs)

--- a/snippets/base/migrations/0008_auto__add_jsonsnippet__add_jsonsnippetlocale__del_field_snippet_on_fir.py
+++ b/snippets/base/migrations/0008_auto__add_jsonsnippet__add_jsonsnippetlocale__del_field_snippet_on_fir.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'JSONSnippet'
+        db.create_table('base_jsonsnippet', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+            ('priority', self.gf('django.db.models.fields.IntegerField')(default=0, blank=True)),
+            ('disabled', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('icon', self.gf('django.db.models.fields.TextField')()),
+            ('text', self.gf('django.db.models.fields.CharField')(max_length=140)),
+            ('url', self.gf('django.db.models.fields.CharField')(max_length=500)),
+            ('country', self.gf('snippets.base.fields.CountryField')(default='', max_length=16, blank=True)),
+            ('publish_start', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('publish_end', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('on_release', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('on_beta', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('on_aurora', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('on_nightly', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('on_startpage_1', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('modified', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+        ))
+        db.send_create_signal('base', ['JSONSnippet'])
+
+        # Adding M2M table for field client_match_rules on 'JSONSnippet'
+        db.create_table('base_jsonsnippet_client_match_rules', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('jsonsnippet', models.ForeignKey(orm['base.jsonsnippet'], null=False)),
+            ('clientmatchrule', models.ForeignKey(orm['base.clientmatchrule'], null=False))
+        ))
+        db.create_unique('base_jsonsnippet_client_match_rules', ['jsonsnippet_id', 'clientmatchrule_id'])
+
+        # Adding model 'JSONSnippetLocale'
+        db.create_table('base_jsonsnippetlocale', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('snippet', self.gf('django.db.models.fields.related.ForeignKey')(related_name='locale_set', to=orm['base.JSONSnippet'])),
+            ('locale', self.gf('snippets.base.fields.LocaleField')(default='en-US', max_length=32)),
+        ))
+        db.send_create_signal('base', ['JSONSnippetLocale'])
+
+        # Deleting field 'Snippet.on_firefox'
+        db.delete_column('base_snippet', 'on_firefox')
+
+        # Deleting field 'Snippet.on_fennec'
+        db.delete_column('base_snippet', 'on_fennec')
+
+
+    def backwards(self, orm):
+        # Deleting model 'JSONSnippet'
+        db.delete_table('base_jsonsnippet')
+
+        # Removing M2M table for field client_match_rules on 'JSONSnippet'
+        db.delete_table('base_jsonsnippet_client_match_rules')
+
+        # Deleting model 'JSONSnippetLocale'
+        db.delete_table('base_jsonsnippetlocale')
+
+        # Adding field 'Snippet.on_firefox'
+        db.add_column('base_snippet', 'on_firefox',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+        # Adding field 'Snippet.on_fennec'
+        db.add_column('base_snippet', 'on_fennec',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    models = {
+        'base.clientmatchrule': {
+            'Meta': {'ordering': "('-modified',)", 'object_name': 'ClientMatchRule'},
+            'appbuildid': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'build_target': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'channel': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'distribution': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'distribution_version': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_exclusion': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'locale': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'os_version': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'startpage_version': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'}),
+            'version': ('snippets.base.fields.RegexField', [], {'max_length': '64', 'blank': 'True'})
+        },
+        'base.jsonsnippet': {
+            'Meta': {'ordering': "('-modified',)", 'object_name': 'JSONSnippet'},
+            'client_match_rules': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['base.ClientMatchRule']", 'symmetrical': 'False', 'blank': 'True'}),
+            'country': ('snippets.base.fields.CountryField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'disabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'icon': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'on_aurora': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_beta': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_nightly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_release': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_1': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'publish_end': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'publish_start': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.CharField', [], {'max_length': '140'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '500'})
+        },
+        'base.jsonsnippetlocale': {
+            'Meta': {'object_name': 'JSONSnippetLocale'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('snippets.base.fields.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'snippet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locale_set'", 'to': "orm['base.JSONSnippet']"})
+        },
+        'base.snippet': {
+            'Meta': {'ordering': "('-modified',)", 'object_name': 'Snippet'},
+            'client_match_rules': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['base.ClientMatchRule']", 'symmetrical': 'False', 'blank': 'True'}),
+            'country': ('snippets.base.fields.CountryField', [], {'default': "''", 'max_length': '16', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'data': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            'disabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'on_aurora': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_beta': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_nightly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_release': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_1': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'on_startpage_2': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_3': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'on_startpage_4': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'publish_end': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'publish_start': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['base.SnippetTemplate']"})
+        },
+        'base.snippetlocale': {
+            'Meta': {'object_name': 'SnippetLocale'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('snippets.base.fields.LocaleField', [], {'default': "'en-US'", 'max_length': '32'}),
+            'snippet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locale_set'", 'to': "orm['base.Snippet']"})
+        },
+        'base.snippettemplate': {
+            'Meta': {'object_name': 'SnippetTemplate'},
+            'code': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'base.snippettemplatevariable': {
+            'Meta': {'object_name': 'SnippetTemplateVariable'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'template': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'variable_set'", 'to': "orm['base.SnippetTemplate']"}),
+            'type': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        }
+    }
+
+    complete_apps = ['base']

--- a/snippets/base/static/js/iconWidget.js
+++ b/snippets/base/static/js/iconWidget.js
@@ -1,0 +1,24 @@
+(function($) {
+    $(document).on('change', '.image-input', function() {
+        if (this.files.length < 1) {
+            return;
+        }
+
+        // Check to see if this is an image
+        var file = this.files[0];
+        if (!file.type.match(/image.*/)) {
+            return;
+        }
+
+        // Load file.
+        var $this = $(this);
+        var preview = $this.siblings('img')[0];
+        var store = $this.siblings('input')[0];
+        var reader = new FileReader();
+        reader.onload = function(e) {
+            preview.src = e.target.result;
+            store.value = e.target.result;
+        };
+        reader.readAsDataURL(file);
+    });
+})(jQuery);

--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -28,10 +28,9 @@ class SnippetTemplateVariableFactory(factory.DjangoModelFactory):
     template = factory.SubFactory(SnippetTemplateFactory)
 
 
-class SnippetFactory(factory.DjangoModelFactory):
+class BaseSnippetFactory(factory.DjangoModelFactory):
     FACTORY_FOR = models.Snippet
     name = factory.Sequence(lambda n: 'Test Snippet {0}'.format(n))
-    template = factory.SubFactory(SnippetTemplateFactory)
     disabled = False
 
     @factory.post_generation
@@ -51,6 +50,15 @@ class SnippetFactory(factory.DjangoModelFactory):
             self.locale_set.add(*extracted)
         else:
             self.locale_set.create(locale='en-us')
+
+
+class SnippetFactory(BaseSnippetFactory):
+    FACTORY_FOR = models.Snippet
+    template = factory.SubFactory(SnippetTemplateFactory)
+
+
+class JSONSnippetFactory(BaseSnippetFactory):
+    FACTORY_FOR = models.JSONSnippet
 
 
 class ClientMatchRuleFactory(factory.DjangoModelFactory):

--- a/snippets/base/tests/test_admin.py
+++ b/snippets/base/tests/test_admin.py
@@ -78,7 +78,9 @@ class SnippetAdminTests(TestCase):
         locales = (l.locale for l in snippet.locale_set.all())
         eq_(set(locales), set(('en-us', 'fr')))
 
-    def test_cmr_to_locales_action_base(self):
+
+class CMRToLocalesActionTests(TestCase):
+    def test_base(self):
         cmr_el = ClientMatchRuleFactory(locale='/^el/')
         cmr_ast = ClientMatchRuleFactory(locale='ast|ja-JP-mac',
                                          channel='aurora')
@@ -95,7 +97,7 @@ class SnippetAdminTests(TestCase):
         eq_(snippet.client_match_rules.count(), 1)
         eq_(snippet.client_match_rules.all()[0], cmr_ast)
 
-    def test_cmr_to_locales_action_exclusion_cmr(self):
+    def test_exclusion_cmr(self):
         cmr_el = ClientMatchRuleFactory(locale='/^el/', is_exclusion=True)
         snippet = SnippetFactory(client_match_rules=[cmr_el],
                                  locale_set=[SnippetLocale(locale='pl'),

--- a/snippets/base/tests/test_cron.py
+++ b/snippets/base/tests/test_cron.py
@@ -115,8 +115,6 @@ class ImportTests(TestCase):
         eq_(snippet.on_startpage_2, True)
         eq_(snippet.on_startpage_3, True)
         eq_(snippet.on_startpage_4, True)
-        eq_(snippet.on_firefox, True)
-        eq_(snippet.on_fennec, True)
         eq_(snippet.id, 4045)
         eq_(snippet.country, '2')
 

--- a/snippets/base/tests/test_encoders.py
+++ b/snippets/base/tests/test_encoders.py
@@ -1,0 +1,24 @@
+from mock import patch
+from nose.tools import eq_
+
+from snippets.base.encoders import SnippetEncoder
+from snippets.base.tests import JSONSnippetFactory, TestCase
+
+
+class SnippetEncoderTests(TestCase):
+    def test_encode_jsonsnippet(self):
+        encoder = SnippetEncoder()
+        data = {'id': 99, 'text': 'test-text',
+                'icon': 'test-icon', 'url': 'test-url',
+                'country': 'US'}
+        snippet = JSONSnippetFactory.build(**data)
+        result = encoder.default(snippet)
+        data['target_geo'] = data.pop('country')
+        eq_(result, data)
+
+    @patch('snippets.base.encoders.json.JSONEncoder.default')
+    def test_encode_other(self, default_mock):
+        encoder = SnippetEncoder()
+        data = {'id': 3}
+        encoder.default(data)
+        default_mock.assert_called_with(data)

--- a/snippets/base/tests/test_forms.py
+++ b/snippets/base/tests/test_forms.py
@@ -1,11 +1,24 @@
 import json
 
+from mock import patch
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
-from snippets.base.forms import TemplateDataWidget, TemplateSelect
+from snippets.base.forms import IconWidget, TemplateDataWidget, TemplateSelect
 from snippets.base.tests import (SnippetTemplateFactory,
                                  SnippetTemplateVariableFactory, TestCase)
+
+
+class IconWidgetTests(TestCase):
+    def test_basic(self):
+        with patch('snippets.base.forms.forms.TextInput.render') as render_mock:
+            render_mock.return_value = 'original widget code'
+            widget = IconWidget()
+            rendered_widget = widget.render('iconname', 'iconvalue')
+        ok_('original widget code' in rendered_widget)
+        d = pq(rendered_widget)
+        eq_(d.find('img').attr('src'), 'iconvalue')
+        ok_(d.attr('id'), 'iconname')
 
 
 class TemplateSelectTests(TestCase):

--- a/snippets/base/tests/test_middleware.py
+++ b/snippets/base/tests/test_middleware.py
@@ -11,7 +11,7 @@ class FetchSnippetsMiddlewareTests(TestCase):
 
     @patch('snippets.base.middleware.resolve')
     @patch('snippets.base.middleware.fetch_snippets')
-    def test_resolve_match(self, fetch_snippets, resolve):
+    def test_resolve_fetch_snippets_match(self, fetch_snippets, resolve):
         """
         If resolve returns a match to the fetch_snippets view, return the
         result of the view.
@@ -25,6 +25,23 @@ class FetchSnippetsMiddlewareTests(TestCase):
         eq_(self.middleware.process_request(request),
             fetch_snippets.return_value)
         fetch_snippets.assert_called_with(request, 1, 'asdf', blah=5)
+
+    @patch('snippets.base.middleware.resolve')
+    @patch('snippets.base.middleware.fetch_json_snippets')
+    def test_resolve_fetch_json_snippets_match(self, fetch_json_snippets, resolve):
+        """
+        If resolve returns a match to the fetch_json_snippets view,
+        return the result of the view.
+        """
+        request = Mock()
+        result = resolve.return_value
+        result.func = fetch_json_snippets
+        result.args = (1, 'asdf')
+        result.kwargs = {'blah': 5}
+
+        eq_(self.middleware.process_request(request),
+            fetch_json_snippets.return_value)
+        fetch_json_snippets.assert_called_with(request, 1, 'asdf', blah=5)
 
     @patch('snippets.base.middleware.resolve')
     @patch('snippets.base.middleware.fetch_snippets')

--- a/snippets/base/urls.py
+++ b/snippets/base/urls.py
@@ -10,7 +10,11 @@ urlpatterns = patterns('',
         '(?P<channel>[^/]+)/(?P<os_version>[^/]+)/(?P<distribution>[^/]+)/'
         '(?P<distribution_version>[^/]+)/$', views.fetch_snippets,
         name='base.fetch_snippets'),
-
+    url(r'^json/(?P<startpage_version>[^/]+)/(?P<name>[^/]+)/(?P<version>[^/]+)/'
+        '(?P<appbuildid>[^/]+)/(?P<build_target>[^/]+)/(?P<locale>[^/]+)/'
+        '(?P<channel>[^/]+)/(?P<os_version>[^/]+)/(?P<distribution>[^/]+)/'
+        '(?P<distribution_version>[^/]+)/$', views.fetch_json_snippets,
+        name='base.fetch_json_snippets'),
     url(r'^preview/$', views.preview_snippet, name='base.preview'),
     url(r'^show/(?P<snippet_id>\d+)/$', views.show_snippet, name='base.show'),
 )


### PR DESCRIPTION
Here is the WIP for snippets for android. 

Notes:
- url: I chose an CharField instead of a URLField in case we want to use special urls like "about:config"
- icon: Since now fields are not dynamic we could to the icon to Data URL conversion on the server, but that would require PIL. I re-purposed the template code to do it FileReader API.
- frontend: The frontend listing active snippets needs update. maybe we can do this as part of another bug.
- admin and views: I tried to re-use as much of the current codebase, by moving shared code to common 'base' classes and views wherever that made sense.
- Snippet weights: Do we want support for that?

This still needs tests and maybe some tweaks here and there. I'm pull requesting this so I can get some feedback on the (refactoring) decisions.

I tested that with Margaret's custom Fennec build and it works! :D
