### PR TITLE
Improve SnippetManager's tests.

### DIFF
--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -50,7 +50,7 @@ class BaseSnippetFactory(factory.DjangoModelFactory):
         if not create:
             return
 
-        if extracted:
+        if extracted is not None:
             self.locale_set.add(*extracted)
         else:
             self.locale_set.create(locale='en-us')


### PR DESCRIPTION
I rewrote SnipperManager tests based on comment https://github.com/mozilla/snippets-service/pull/46#discussion-diff-8197142R74. I added a couple tests to cover things that we didn't check until now, like `test_match_client_invalid_locale` and `test_match_client_match_channel_partially`.
