### PR TITLE
Fix bug 970894: Move snippet preview form outside of main form.

### DIFF
--- a/snippets/base/static/css/templateDataWidget.css
+++ b/snippets/base/static/css/templateDataWidget.css
@@ -50,11 +50,15 @@
 .snippet-preview-container {
     border-top: 1px solid #DDD;
     height: 480px;
-    width: 640px;
+    width: 100%;
 }
 
 .snippet-preview-container iframe {
     border: none;
     height: 100%;
     width: 100%;
+}
+
+.snippet-preview-form {
+    display: none;
 }

--- a/snippets/base/static/js/templateDataWidget.js
+++ b/snippets/base/static/js/templateDataWidget.js
@@ -203,11 +203,12 @@
         this.dataWidget = dataWidget;
 
         this.$container = $(elem);
-        this.$container.html(nj.render('snippetPreview.html', {
+        this.$container.html(nj.render('snippetPreviewFrame.html'));
+
+        this.$form = $(nj.render('snippetPreviewForm.html', {
             preview_url: this.$container.data('previewUrl')
         }));
-
-        this.$form = this.$container.find('form');
+        $(document.body).append(this.$form);
         this.$dataInput = this.$form.find('input[name="data"]');
         this.$templateIdInput = this.$form.find('input[name="template_id"]');
 

--- a/snippets/base/static/templates/snippetPreview.html
+++ b/snippets/base/static/templates/snippetPreview.html
@@ -1,5 +1,0 @@
-<iframe name="snippet-preview" class="snippet-preview"></iframe>
-<form target="snippet-preview" method="post" action="{{ preview_url }}">
-  <input type="text" name="data">
-  <input type="text" name="template_id">
-</form>

--- a/snippets/base/static/templates/snippetPreviewForm.html
+++ b/snippets/base/static/templates/snippetPreviewForm.html
@@ -1,0 +1,4 @@
+<form class="snippet-preview-form" target="snippet-preview" method="post" action="{{ preview_url }}">
+  <input type="text" name="data">
+  <input type="text" name="template_id">
+</form>

--- a/snippets/base/static/templates/snippetPreviewFrame.html
+++ b/snippets/base/static/templates/snippetPreviewFrame.html
@@ -1,0 +1,2 @@
+<iframe name="snippet-preview" class="snippet-preview"></iframe>
+


### PR DESCRIPTION
hoosteeno tracked down an issue with the snippet preview to the fact 
that it used a form within a form, which isn't allowed by the html5 spec
and apparently doesn't work in Nightly anymore. We fix it by moving the
preview form outside of the containing form.
