### PR TITLE
Fix bug 1054472: Use ETags to determine if we can send 304s.

### DIFF
--- a/snippets/base/middleware.py
+++ b/snippets/base/middleware.py
@@ -1,20 +1,16 @@
 from django.core.urlresolvers import resolve
 
-from snippets.base.views import fetch_json_snippets, fetch_snippets
 
-
-class FetchSnippetsMiddleware(object):
+class SkipMiddleware(object):
     """
-    If the incoming request is for the fetch_snippets view, execute the view
-    and return it before other middleware can run.
+    If the incoming request is for a view that has the skip_middleware
+    kwarg, execute the view and return the response before other
+    middleware can run.
 
-    fetch_snippets is a very very basic view that doesn't need any of the
-    middleware that the rest of the site needs, such as the session or csrf
-    middlewares. To avoid unintended issues (such as headers we don't want
-    being added to the response) this middleware detects requests to that view
-    and executes the view early, bypassing the rest of the middleware.
+    Allows views like the FetchSnippets view to bypass unnecessary
+    middleware.
     """
     def process_request(self, request):
         result = resolve(request.path)
-        if result.func in (fetch_snippets, fetch_json_snippets):
+        if result.kwargs.pop('skip_middleware', False):
             return result.func(request, *result.args, **result.kwargs)

--- a/snippets/base/templates/base/fetch_snippets.html
+++ b/snippets/base/templates/base/fetch_snippets.html
@@ -5,4 +5,3 @@
   {% endfor %}
   {% include 'base/includes/snippet_js.html' %}
 </div>
-<!-- Content generated at {{ current_time }} -->

--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -64,3 +64,27 @@ class JSONSnippetFactory(BaseSnippetFactory):
 class ClientMatchRuleFactory(factory.DjangoModelFactory):
     FACTORY_FOR = models.ClientMatchRule
     description = factory.Sequence(lambda n: 'Client Match Rule {0}'.format(n))
+
+
+class CONTAINS(object):
+    """
+    Helper object that is equal to any object that contains a specific
+    value.
+
+    If exclusive=True is passed to the constructor, sets will be used
+    for comparison, meaning that an iterable is equal to this object
+    only if it contains the same values given in the constructor,
+    ignoring the order of values.
+    """
+    def __init__(self, *values, **kwargs):
+        self.values = values
+        self.exclusive = kwargs.get('exclusive', False)
+
+    def __eq__(self, other):
+        if self.exclusive:
+            return set(v for v in other) == set(self.values)
+        else:
+            return all(v in other for v in self.values)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/snippets/base/tests/test_middleware.py
+++ b/snippets/base/tests/test_middleware.py
@@ -1,57 +1,27 @@
-from mock import Mock, patch
+from django.test.client import RequestFactory
+
 from nose.tools import eq_
 
-from snippets.base.middleware import FetchSnippetsMiddleware
+from snippets.base.middleware import SkipMiddleware
 from snippets.base.tests import TestCase
 
 
-class FetchSnippetsMiddlewareTests(TestCase):
+class SkipMiddlewareTests(TestCase):
+    urls = 'snippets.base.tests.urls'
+
     def setUp(self):
-        self.middleware = FetchSnippetsMiddleware()
+        self.middleware = SkipMiddleware()
+        self.factory = RequestFactory()
 
-    @patch('snippets.base.middleware.resolve')
-    @patch('snippets.base.middleware.fetch_snippets')
-    def test_resolve_fetch_snippets_match(self, fetch_snippets, resolve):
-        """
-        If resolve returns a match to the fetch_snippets view, return the
-        result of the view.
-        """
-        request = Mock()
-        result = resolve.return_value
-        result.func = fetch_snippets
-        result.args = (1, 'asdf')
-        result.kwargs = {'blah': 5}
-
-        eq_(self.middleware.process_request(request),
-            fetch_snippets.return_value)
-        fetch_snippets.assert_called_with(request, 1, 'asdf', blah=5)
-
-    @patch('snippets.base.middleware.resolve')
-    @patch('snippets.base.middleware.fetch_json_snippets')
-    def test_resolve_fetch_json_snippets_match(self, fetch_json_snippets, resolve):
-        """
-        If resolve returns a match to the fetch_json_snippets view,
-        return the result of the view.
-        """
-        request = Mock()
-        result = resolve.return_value
-        result.func = fetch_json_snippets
-        result.args = (1, 'asdf')
-        result.kwargs = {'blah': 5}
-
-        eq_(self.middleware.process_request(request),
-            fetch_json_snippets.return_value)
-        fetch_json_snippets.assert_called_with(request, 1, 'asdf', blah=5)
-
-    @patch('snippets.base.middleware.resolve')
-    @patch('snippets.base.middleware.fetch_snippets')
-    def test_resolve_no_match(self, fetch_snippets, resolve):
-        """
-        If resolve doesn't return a match to the fetch_snippets view, return
-        None.
-        """
-        request = Mock()
-        result = resolve.return_value
-        result.func = lambda request: 'asdf'
-
+    def test_process_request_no_kwargs(self):
+        """If the skip_middleware kwarg is missing, return None."""
+        request = self.factory.get('test')
         eq_(self.middleware.process_request(request), None)
+
+    def test_process_request_kwargs(self):
+        """
+        If the skip_middleware kwarg is present, execute the view and
+        return the response.
+        """
+        request = self.factory.get('test_skip')
+        eq_(self.middleware.process_request(request), 'skipped')

--- a/snippets/base/tests/urls.py
+++ b/snippets/base/tests/urls.py
@@ -1,0 +1,16 @@
+from django.conf.urls.defaults import patterns, url
+
+
+def test_view(request):
+    return 'test'
+
+
+def test_view_skip_middleware(request):
+    return 'skipped'
+
+
+urlpatterns = patterns('',
+    url(r'^test$', test_view),
+    url(r'^test_skip$', test_view_skip_middleware, {'skip_middleware': True}),
+)
+

--- a/snippets/base/urls.py
+++ b/snippets/base/urls.py
@@ -8,13 +8,13 @@ urlpatterns = patterns('',
     url(r'^(?P<startpage_version>[^/]+)/(?P<name>[^/]+)/(?P<version>[^/]+)/'
         '(?P<appbuildid>[^/]+)/(?P<build_target>[^/]+)/(?P<locale>[^/]+)/'
         '(?P<channel>[^/]+)/(?P<os_version>[^/]+)/(?P<distribution>[^/]+)/'
-        '(?P<distribution_version>[^/]+)/$', views.fetch_snippets,
-        name='base.fetch_snippets'),
+        '(?P<distribution_version>[^/]+)/$', views.FetchSnippets.as_view(),
+        kwargs={'skip_middleware': True}, name='base.fetch_snippets'),
     url(r'^json/(?P<startpage_version>[^/]+)/(?P<name>[^/]+)/(?P<version>[^/]+)/'
         '(?P<appbuildid>[^/]+)/(?P<build_target>[^/]+)/(?P<locale>[^/]+)/'
         '(?P<channel>[^/]+)/(?P<os_version>[^/]+)/(?P<distribution>[^/]+)/'
         '(?P<distribution_version>[^/]+)/$', views.fetch_json_snippets,
-        name='base.fetch_json_snippets'),
+        kwargs={'skip_middleware': True}, name='base.fetch_json_snippets'),
     url(r'^preview/$', views.preview_snippet, name='base.preview'),
     url(r'^show/(?P<snippet_id>\d+)/$', views.show_snippet, name='base.show'),
 )

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -1,14 +1,18 @@
 import json
-from time import gmtime, strftime
+import hashlib
 
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
+from django.core.cache import cache
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.http import Http404,HttpResponse, HttpResponseBadRequest
+from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseNotModified
 from django.shortcuts import get_object_or_404, render
+from django.utils.cache import patch_vary_headers
+from django.utils.decorators import method_decorator
 from django.utils.functional import lazy
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import csrf_exempt
+from django.views.generic import View
 
 from commonware.response.decorators import xframe_allow
 
@@ -56,23 +60,80 @@ def index(request):
     return render(request, 'base/index.html', data)
 
 
-@cache_control(public=True, max_age=HTTP_MAX_AGE)
-@access_control(max_age=HTTP_MAX_AGE)
-def fetch_snippets(request, **kwargs):
-    client = Client(**kwargs)
-    matching_snippets = (Snippet.cached_objects
-                         .filter(disabled=False)
-                         .match_client(client)
-                         .order_by('priority')
-                         .select_related('template')
-                         .filter_by_available())
+class FetchSnippets(View):
+    @method_decorator(cache_control(public=True, max_age=HTTP_MAX_AGE))
+    @method_decorator(access_control(max_age=HTTP_MAX_AGE))
+    def dispatch(self, *args, **kwargs):
+        return super(FetchSnippets, self).dispatch(*args, **kwargs)
 
-    return render(request, 'base/fetch_snippets.html', {
-        'snippets': matching_snippets,
-        'client': client,
-        'current_time': strftime('%Y-%m-%dT%H:%M:%SZ', gmtime()),
-        'locale': client.locale,
-    })
+    def get(self, request, *args, **kwargs):
+        """
+        Fetch snippets matching the user's client and return them in
+        rendered format. If the client has already cached the snippets
+        we're going to send them, return a 304.
+
+        When we send a response, we cache the ETag of the response
+        (which is a hash of the response content) under a key generated
+        from the client.
+
+        When a client requests snippets, we compare the incoming ETag
+        with the ETag stored in the cache. If they match, we know the
+        user already has a cached copy of the snippets we'd be sending
+        them and can return a 304 instead of making them re-download.
+        """
+        client = Client(**kwargs)
+
+        request_etag = request.META.get('HTTP_IF_NONE_MATCH')
+        key = self.get_client_cache_key(client)
+        cached_etag = cache.get(key)
+
+        # If the request's ETag matches the cached one, we're done!
+        if request_etag and request_etag == cached_etag:
+            return HttpResponseNotModified()
+
+        # Otherwise, we'll need the response.
+        response = self.generate_response(request, client)
+
+        # If the cache is empty or doesn't match the response we just
+        # generated, we need to update the cache
+        if cached_etag is None or cached_etag != response['ETag']:
+            cache.set(key, response['ETag'], settings.ETAG_CACHE_TIMEOUT)
+
+        # If the request's ETag matches the response's ETag, we can
+        # send a 304 and save some bandwidth.
+        if request_etag == response['ETag']:
+            return HttpResponseNotModified()
+
+        # Otherwise, we need to send the user new snippets.
+        return response
+
+    def get_client_cache_key(self, client):
+        """Generate a cache key for storing the given client's ETag."""
+        return repr(client) + '_etag'  # Namedtuples have a decent repr.
+
+    def generate_response(self, request, client):
+        """
+        Fetch snippets matching the given client and generate an
+        HttpResponse containing the rendered snippets.
+        """
+        matching_snippets = (Snippet.cached_objects
+                             .filter(disabled=False)
+                             .match_client(client)
+                             .order_by('priority')
+                             .select_related('template')
+                             .filter_by_available())
+
+        response = render(request, 'base/fetch_snippets.html', {
+            'snippets': matching_snippets,
+            'client': client,
+            'locale': client.locale,
+        })
+
+        # ETag will be a hash of the response content.
+        response['ETag'] = hashlib.sha256(response.content).hexdigest()
+        patch_vary_headers(response, ['If-None-Match'])
+
+        return response
 
 
 @cache_control(public=True, max_age=HTTP_MAX_AGE)

--- a/snippets/settings/base.py
+++ b/snippets/settings/base.py
@@ -61,7 +61,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'snippets.base.middleware.FetchSnippetsMiddleware',
+    'snippets.base.middleware.SkipMiddleware',
     'multidb.middleware.PinningRouterMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -83,3 +83,7 @@ def _allowed_hosts():
     host = host.rsplit(':', 1)[0]  # Remove port
     return [host]
 ALLOWED_HOSTS = lazy(_allowed_hosts, list)()
+
+
+# Cache timeout for storing Client -> ETag mappings in the database.
+ETAG_CACHE_TIMEOUT = 60 * 15  # 15 minutes


### PR DESCRIPTION
Changes the fetch_snippets view to add ETags to outgoing responses that
are a hash of their content. It then uses the incoming ETags from
clients to determine what snippet content the client currently has 
cached, and whether new snippet content needs to be delivered or if a
304 can be sent to instruct the client to use their cached snippets.

This should allow us to increase the frequency of updates by lowering
the amount of data we need to send.
