### PR TITLE
[fix bug 1059714] Add 'Save As' button for Snippets and JsonSnippets.

### DIFF
--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -91,6 +91,7 @@ class BaseSnippetAdmin(BaseModelAdmin):
 
     readonly_fields = ('created', 'modified')
     save_on_top = True
+    save_as = True
 
     filter_horizontal = ('client_match_rules',)
 
@@ -105,6 +106,12 @@ class BaseSnippetAdmin(BaseModelAdmin):
                 obj.locale_set.create(locale=locale)
         except KeyError:
             pass  # If the locales weren't even specified, do nothing.
+
+    def change_view(self, request, *args, **kwargs):
+        if request.method == 'POST' and '_saveasnew' in request.POST:
+            # Always saved cloned snippets as disabled.
+            request.POST['disabled'] = u'on'
+        return super(BaseSnippetAdmin, self).change_view(request, *args, **kwargs)
 
 
 class SnippetAdmin(BaseSnippetAdmin):

--- a/snippets/base/tests/test_admin.py
+++ b/snippets/base/tests/test_admin.py
@@ -78,6 +78,34 @@ class SnippetAdminTests(TestCase):
         locales = (l.locale for l in snippet.locale_set.all())
         eq_(set(locales), set(('en-us', 'fr')))
 
+    def test_save_as_disabled(self):
+        request = self.factory.post('/', data={
+            'name': 'test',
+            'template': 'foo',
+            'disabled': u'off',
+            '_saveasnew': True
+        })
+        
+        with patch('snippets.base.admin.BaseModelAdmin.change_view') as change_view_mock:
+            self.model_admin.change_view(request, 999)
+            change_view_mock.assert_called_with(request, 999)
+            request = change_view_mock.call_args[0][0]
+            eq_(request.POST['disabled'], u'on')
+
+    def test_normal_save_disabled(self):
+        """Test that normal save doesn't alter 'disabled' attribute."""
+        request = self.factory.post('/', data={
+            'name': 'test',
+            'template': 'foo',
+            'disabled': u'foo'
+        })
+
+        with patch('snippets.base.admin.BaseModelAdmin.change_view') as change_view_mock:
+            self.model_admin.change_view(request, 999)
+            change_view_mock.assert_called_with(request, 999)
+            request = change_view_mock.call_args[0][0]
+            eq_(request.POST['disabled'], u'foo')
+
 
 class CMRToLocalesActionTests(TestCase):
     def test_base(self):


### PR DESCRIPTION
We force disabled=True for cloned snippets to avoid mistakes.
