### PR TITLE
Bug 1054410: Accommodate snippets with root tags w/o “snippet” class.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -221,7 +221,8 @@ class Snippet(CachingMixin, models.Model):
 
         # Use a list for attrs to make the output order predictable.
         attrs = [('data-snippet-id', self.id),
-                 ('data-weight', self.weight)]
+                 ('data-weight', self.weight),
+                 ('class', 'snippet-metadata')]
         if self.country:
             attrs.append(('data-country', self.country))
         attr_string = ' '.join('{0}="{1}"'.format(key, value) for key, value in

--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -58,8 +58,17 @@
             // activateSnippetsButtonClick
         }
 
-        // Send impression to the snippets stats server.
-        var show_snippet_id = show_snippet.parentNode.dataset.snippetId;
+        // Determine snippet ID.
+        var metaParent = show_snippet.parentNode;
+        while (metaParent && metaParent.classList &&
+               metaParent.classList.contains('snippet-metadata')) {
+            metaParent = metaParent.parentNode;
+        }
+
+        var show_snippet_id = 'unknown';
+        if (metaParent) {
+            show_snippet_id = metaParent.dataset.snippetId || 'unknown';
+        }
         send_impression(show_snippet_id);
 
         // Trigger show_snippet event on snippet node.

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -131,8 +131,8 @@ class SnippetTests(TestCase):
         snippet = SnippetFactory.create(template=template, data=data,
                                         country='us', weight=60)
 
-        expected = ('<div data-snippet-id="{0}" data-weight="60" data-country="us">'
-                    '<a href="asdf">qwer</a></div>'.format(snippet.id))
+        expected = ('<div data-snippet-id="{0}" data-weight="60" class="snippet-metadata" '
+                    'data-country="us"><a href="asdf">qwer</a></div>'.format(snippet.id))
         eq_(snippet.render().strip(), expected)
         template.render.assert_called_with({
             'url': 'asdf',
@@ -152,7 +152,7 @@ class SnippetTests(TestCase):
         data = '{"url": "asdf", "text": "qwer"}'
         snippet = SnippetFactory.create(template=template, data=data)
 
-        expected = ('<div data-snippet-id="{0}" data-weight="100">'
+        expected = ('<div data-snippet-id="{0}" data-weight="100" class="snippet-metadata">'
                     '<a href="asdf">qwer</a></div>'
                     .format(snippet.id))
         eq_(snippet.render().strip(), expected)


### PR DESCRIPTION
The JavaScript previously assumed that the parent element of the 
“snippet”-classed element had the metadata for a snippet, such as its
ID. Raw snippets may have an extra surrounding element for styling or
other reasons, and instead of mandating that the root element of a 
snippet be the snippet-classed element, this updates the JavaScript to
search for the closest parent element with the “snippet-metadata” class.
