### PR TITLE
[bug 1063585] Lowercase tagName before comparing with 'a'.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -230,7 +230,7 @@
     // convert them showFirefoxAccounts Events.
     document.addEventListener('click', function(event) {
         var target = event.target;
-        while (target && target.tagName !== 'a') {
+        while (target && target.tagName.toLowerCase() !== 'a') {
             target = target.parentNode;
         }
         if (target && target.href.indexOf('about:accounts') === 0) {


### PR DESCRIPTION
@Osmose r?
