### PR TITLE
Remove instant preview from the snippet admin form.

### DIFF
--- a/snippets/base/static/css/templateDataWidget.css
+++ b/snippets/base/static/css/templateDataWidget.css
@@ -50,16 +50,11 @@
 
 .snippet-preview-container {
     border-top: 1px solid #DDD;
-    height: 480px;
     width: 100%;
 }
 
-.snippet-preview-container iframe {
-    border: none;
-    height: 100%;
-    width: 100%;
-}
-
-.snippet-preview-form {
-    display: none;
+.snippet-preview-form button {
+    margin: 5px auto;
+    display: block;
+    width: 200px;
 }

--- a/snippets/base/static/js/templateDataWidget.js
+++ b/snippets/base/static/js/templateDataWidget.js
@@ -211,27 +211,24 @@
         this.dataWidget = dataWidget;
 
         this.$container = $(elem);
-        this.$container.html(nj.render('snippetPreviewFrame.html'));
-
         this.$form = $(nj.render('snippetPreviewForm.html', {
             preview_url: this.$container.data('previewUrl')
         }));
-        $(document.body).append(this.$form);
+        this.$container.append(this.$form);
+
         this.$dataInput = this.$form.find('input[name="data"]');
         this.$templateIdInput = this.$form.find('input[name="template_id"]');
 
-        dataWidget.onDataChange(function() {
-            self.onDataChange();
+        this.$form.submit(function() {
+            self.onFormSubmit();
         });
-        self.onDataChange(); // Trigger initial preview.
     }
 
     SnippetPreview.prototype = {
-        onDataChange: function() {
+        onFormSubmit: function() {
             var data = JSON.stringify(this.dataWidget.generateData());
             this.$dataInput.val(data);
             this.$templateIdInput.val(this.dataWidget.getTemplateId());
-            this.$form.submit();
         }
     };
 

--- a/snippets/base/static/templates/snippetPreviewForm.html
+++ b/snippets/base/static/templates/snippetPreviewForm.html
@@ -1,4 +1,5 @@
-<form class="snippet-preview-form" target="snippet-preview" method="post" action="{{ preview_url }}">
-  <input type="text" name="data">
-  <input type="text" name="template_id">
+<form class="snippet-preview-form" target="_blank" method="post" action="{{ preview_url }}">
+  <input type="hidden" name="data">
+  <input type="hidden" name="template_id">
+  <button type="submit">Preview Snippet</button>
 </form>

--- a/snippets/base/static/templates/snippetPreviewFrame.html
+++ b/snippets/base/static/templates/snippetPreviewFrame.html
@@ -1,2 +1,0 @@
-<iframe name="snippet-preview" class="snippet-preview"></iframe>
-


### PR DESCRIPTION
The instant preview has a few issues:
- Occasional errors due to weird iframe back-forward behavior.
- Slowness in editing large snippets due to constant sending of snippet
  data, as well as from snippets that take up some CPU.
- Restrictions on functionality due to being in an iframe.

Thus I’ve removed the iframe and the instant preview and added a button
to trigger a preview in a new tab.
