### PR TITLE
Allow use of snippet_id in template variables.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -222,8 +222,13 @@ class Snippet(CachingMixin, models.Model):
 
     def render(self):
         data = json.loads(self.data)
-        if self.id:
-            data.setdefault('snippet_id', self.id)
+        snippet_id = self.id or 0
+        data.setdefault('snippet_id', snippet_id)
+
+        # Add snippet ID to template variables.
+        for key, value in data.items():
+            if isinstance(value, basestring):
+                data[key] = value.replace(u'<snippet_id>', unicode(snippet_id))
 
         # Use a list for attrs to make the output order predictable.
         attrs = [('data-snippet-id', self.id),

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -182,10 +182,22 @@ class SnippetTests(TestCase):
 
     def test_render_no_snippet_id(self):
         """
-        If a snippet that hasn't been saved to the database yet is rendered, the snippet ID
-        shouldn't be included in the template context.
+        If a snippet that hasn't been saved to the database yet is
+        rendered, the snippet ID should be set to 0.
         """
         snippet = SnippetFactory.build(template__code='<p>{{ snippet_id }}</p>')
         snippet.template.render = Mock()
         snippet.render()
-        snippet.template.render.assert_called_with({})
+        snippet.template.render.assert_called_with({'snippet_id': 0})
+
+    def test_render_data_with_snippet_id(self):
+        """
+        Any strings included in the template context should have the
+        substring "<snippet_id>" replaced with the ID of the snippet.
+        """
+        snippet = SnippetFactory.build(template__code='<p>{{ code }}</p>',
+                                       data='{"code": "snippet id <snippet_id>", "foo": true}')
+        snippet.template.render = Mock()
+        snippet.render()
+        snippet.template.render.assert_called_with({'code': 'snippet id 0', 'snippet_id': 0,
+                                                    'foo': True})


### PR DESCRIPTION
Now the snippet ID can be included in either a snippet template or the
template data stored on a snippet. Mostly useful for Raw code snippets
that still want to access the snippet ID.
