### PR TITLE
Stop hiding Client Match Rules on the snippet admin page.

### DIFF
--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -147,7 +147,6 @@ class SnippetAdmin(BaseSnippetAdmin):
         }),
         ('Client Match Rules', {
             'fields': ('client_match_rules',),
-            'classes': ('collapse',)
         }),
         ('Startpage Versions', {
             'fields': (('on_startpage_1', 'on_startpage_2', 'on_startpage_3',
@@ -260,7 +259,6 @@ class JSONSnippetAdmin(BaseSnippetAdmin):
         }),
         ('Client Match Rules', {
             'fields': ('client_match_rules',),
-            'classes': ('collapse',)
         }),
         ('Startpage Versions', {
             'fields': (('on_startpage_1',),),


### PR DESCRIPTION
Because Every time I open that section I wish I didn’t have to.
