### PR TITLE
Remove un-needed pip install from docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,7 +22,6 @@ have ``pip`` installed, you can install it with ``easy_install pip``.
     $ pip install virtualenv
     $ virtualenv venv
     $ source venv/bin/activate
-    $ pip install -r requirements/compiled.txt
     $ pip install -r requirements/dev.txt
 
 .. note:: The adventurous may prefer to use virtualenvwrapper_ instead of


### PR DESCRIPTION
The dev requirements include installing the prod and compile dependencies anyway so there is no need for this line in the install guide.

cc/ @Osmose 
