### PR TITLE
Disable sampling for snippet previews

### DIFF
--- a/snippets/base/templates/base/includes/snippet_js.html
+++ b/snippets/base/templates/base/includes/snippet_js.html
@@ -328,6 +328,12 @@ var SNIPPET_METRICS_SAMPLE_RATE = 0.1;
 // Send impressions and other interactions to the service
 // If no parameter is entered, quit function
 function sendMetric(metric) {
+    {# In preview mode, disable sampling, log metric, but do not send to service #}
+    {% if preview %}
+    console.log("[preview mode] Sending metric: " + metric);
+    return;
+    {% endif %}
+
     if (Math.random() > SNIPPET_METRICS_SAMPLE_RATE) {
         return;
     }


### PR DESCRIPTION
As we ramp up the type of metrics we're tracking within a snippet, it would be helpful to test that the metrics are sending without being subjected to sampling.
