### PR TITLE
[bug 1378695] Adjust Activity Stream Payload.

### DIFF
--- a/snippets/base/templates/base/fetch_snippets_as.jinja
+++ b/snippets/base/templates/base/fetch_snippets_as.jinja
@@ -1,16 +1,13 @@
 <style type="text/css">
   {% include 'base/includes/snippet_as.css' %}
 </style>
-<script type="text/javascript">
- //<![CDATA[
+<script type="application/javascript">
  // Generated on {{ utcnow() }}
  // Included snippets:
-     {% for id in snippet_ids %}
+ {% for id in snippet_ids %}
  //  - {{ id }}
-     {% endfor %}
-     var ABOUTHOME_SNIPPETS = JSON.parse("{{ snippets_json|escapejs|safe }}");
-     var CURRENT_RELEASE = {{ current_firefox_version }};
-     {% include 'base/includes/snippet_as.js' %}
-
- //]]>
+ {% endfor %}
+ var ABOUTHOME_SNIPPETS = JSON.parse("{{ snippets_json|escapejs|safe }}");
+ var CURRENT_RELEASE = {{ current_firefox_version }};
+ {% include 'base/includes/snippet_as.js' %}
 </script>


### PR DESCRIPTION
 - Remove UITour
 - Remove appInfo, searchengine, fxaccount updaters. Attrs are provided by AS
   directly into gSnippetsMap.
 - Remove gSnippetsMap initialization
 - Remove keypressIsMine workaround (bug 1238092)
 - Adjust addSnippetBlockLinks
 - Remove CDATA since we don't need to be XML valid anymore.
 - Adjust click listener.
 - Remove obsolete code.
 - Remove about:account link handling, since we cannot do it anymore
   without UITour