### PR TITLE
Don't initialize snippets if onboardingFinished is false.

### DIFF
--- a/snippets/base/templates/base/includes/snippet_as.js
+++ b/snippets/base/templates/base/includes/snippet_as.js
@@ -10,6 +10,11 @@ var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days
 (function() {
     'use strict';
 
+    // If onboarding hasn't finished its tour, don't load snippets.
+    if (!gSnippetsMap.get('appData.onboardingFinished')) {
+      return;
+    }
+
     if (ABOUTHOME_SNIPPETS.length > 0) {
         ABOUTHOME_SHOWN_SNIPPET = chooseSnippet(ABOUTHOME_SNIPPETS);
     }


### PR DESCRIPTION
In our previous meeting, some concerns were raised about being to override onboarding if necessary. For this reason, I think it would be a good idea to move the logic about whether to show snippets based on onboarding to the service, rather than in Activity Stream (since it would give individual snippets more control)