### PR TITLE
Don't expire the bundle key in the cache.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -226,7 +226,7 @@ class SnippetBundle(object):
         if isinstance(bundle_content, unicode):
             bundle_content = bundle_content.encode('utf-8')
         default_storage.save(self.filename, ContentFile(bundle_content))
-        cache.set(self.cache_key, True, settings.SNIPPET_BUNDLE_TIMEOUT)
+        cache.set(self.cache_key, True, None)
 
 
 class SnippetTemplate(CachingMixin, models.Model):

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -455,7 +455,7 @@ class SnippetBundleTests(TestCase):
             'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
-        cache.set.assert_called_with(bundle.cache_key, True, 10)
+        cache.set.assert_called_with(bundle.cache_key, True, None)
 
         # Check content of saved file.
         content_file = default_storage.save.call_args[0][1]
@@ -490,7 +490,7 @@ class SnippetBundleTests(TestCase):
             'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
-        cache.set.assert_called_with(bundle.cache_key, True, 10)
+        cache.set.assert_called_with(bundle.cache_key, True, None)
 
         # Check content of saved file.
         content_file = default_storage.save.call_args[0][1]


### PR DESCRIPTION
The snippet bundle cache key is calculated (also) based on the snippet.modified value. So if a snippet to be included in the bundle gets modified the key will and thus a new bundle will be generated. There 's no need to expire the bundles after `settings.SNIPPET_BUNDLE_TIMEOUT` minutes. Instead let them get evicted from the cached and replaced by newer bundle key.

This should reduce the CPU usage of the snippets-service and provide the exact same experience.

Tested on Tokyo and Frankfurt with real traffic and the verified that bundles do get generated only when a snippet changes.