### PR TITLE
Store bundles in cache instead of in S3.

### DIFF
--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -1,10 +1,18 @@
 from django.test import TransactionTestCase
+from django.test.utils import override_settings
 
 import factory
 
 from snippets.base import models
 
 
+@override_settings(CACHALOT_ENABLED=False)
+@override_settings(
+    CACHES={
+        'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'},
+        'cachalot': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'},
+        'product-details': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'},
+    })
 class TestCase(TransactionTestCase):
     pass
 

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -7,7 +7,7 @@ from distutils.util import strtobool
 from django.conf import settings
 from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.utils.cache import patch_vary_headers
 from django.utils.functional import lazy
@@ -93,70 +93,27 @@ class JSONSnippetIndexView(IndexView):
         return self.render(request, *args, **kwargs)
 
 
-@cache_control(public=True, max_age=settings.SNIPPET_BUNDLE_TIMEOUT)
-@access_control(max_age=settings.SNIPPET_BUNDLE_TIMEOUT)
-def fetch_pregenerated_snippets(request, **kwargs):
+@cache_control(public=True, max_age=HTTP_MAX_AGE)
+@access_control(max_age=HTTP_MAX_AGE)
+def fetch_snippets(request, **kwargs):
+    """Return a bundle of snippets for the client. If the bundle in question is
+    expired, re-generate it.
+
     """
-    Return a redirect to a pre-generated bundle of snippets for the
-    client. If the bundle in question is expired, re-generate it.
-    """
+    statsd.incr('serve.snippets')
     client = Client(**kwargs)
     bundle = SnippetBundle(client)
     if bundle.expired:
-        bundle.generate()
         statsd.incr('bundle.generate')
     else:
         statsd.incr('bundle.cached')
 
-    return HttpResponseRedirect(bundle.url)
-
-
-@cache_control(public=True, max_age=HTTP_MAX_AGE)
-@access_control(max_age=HTTP_MAX_AGE)
-def fetch_render_snippets(request, **kwargs):
-    """Fetch snippets for the client and render them immediately."""
-    client = Client(**kwargs)
-    matching_snippets = (Snippet.objects
-                         .filter(disabled=False)
-                         .match_client(client)
-                         .select_related('template')
-                         .filter_by_available())
-
-    current_firefox_version = (
-        version_list(product_details.firefox_history_major_releases)[0].split('.', 1)[0])
-
-    metrics_url = settings.METRICS_URL
-    if ((settings.ALTERNATE_METRICS_URL and
-         client.channel in settings.ALTERNATE_METRICS_CHANNELS)):
-        metrics_url = settings.ALTERNATE_METRICS_URL
-
-    template = 'base/fetch_snippets.jinja'
-
-    if client.startpage_version == '5':
-        template = 'base/fetch_snippets_as.jinja'
-    response = render(request, template, {
-        'snippet_ids': [snippet.id for snippet in matching_snippets],
-        'snippets_json': json.dumps([s.to_dict() for s in matching_snippets]),
-        'client': client,
-        'locale': client.locale,
-        'current_firefox_version': current_firefox_version,
-        'metrics_url': metrics_url,
-    })
-
+    response = HttpResponse(bundle.contents)
     # ETag will be a hash of the response content.
     response['ETag'] = hashlib.sha256(response.content).hexdigest()
     patch_vary_headers(response, ['If-None-Match'])
 
     return response
-
-
-def fetch_snippets(request, **kwargs):
-    """Determine which snippet-fetching method to use."""
-    statsd.incr('serve.snippets')
-    if settings.SERVE_SNIPPET_BUNDLES:
-        return fetch_pregenerated_snippets(request, **kwargs)
-    else:
-        return fetch_render_snippets(request, **kwargs)
 
 
 @cache_control(public=True, max_age=HTTP_MAX_AGE)

--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -148,7 +148,6 @@ if not DEBUG_TEMPLATE:
 MEDIA_URL = config('MEDIA_URL', '/media/')
 MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))
 MEDIA_FILES_ROOT = config('MEDIA_FILES_ROOT', default='files/')
-MEDIA_BUNDLES_ROOT = config('MEDIA_BUNDLES_ROOT', default='bundles/')
 
 SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE', default=not DEBUG, cast=bool)
 
@@ -239,8 +238,6 @@ CACHES = {
     }
 }
 
-SERVE_SNIPPET_BUNDLES = config('SERVE_SNIPPET_BUNDLES', default=not DEBUG, cast=bool)
-
 GEO_URL = 'https://location.services.mozilla.com/v1/country?key=fff72d56-b040-4205-9a11-82feda9d83a3'  # noqa
 
 PROD_DETAILS_CACHE_NAME = 'product-details'
@@ -261,17 +258,14 @@ if DEFAULT_FILE_STORAGE == 'snippets.base.storage.S3Storage':
     AWS_S3_HOST = config('AWS_S3_HOST')
     AWS_CACHE_CONTROL_HEADERS = {
         MEDIA_FILES_ROOT: 'max-age=900',  # 15 Minutes
-        MEDIA_BUNDLES_ROOT: 'max-age=2592000',  # 1 Month
     }
 
 DEAD_MANS_SNITCH_URL = config('DEAD_MANS_SNITCH_URL', default=None)
 
-SNIPPET_HTTP_MAX_AGE = config('SNIPPET_HTTP_MAX_AGE', default=90)
+SNIPPET_HTTP_MAX_AGE = config('SNIPPET_HTTP_MAX_AGE', default=900)
 SNIPPETS_PER_PAGE = config('SNIPPETS_PER_PAGE', default=50)
 
 ENGAGE_ROBOTS = config('ENGAGE_ROBOTS', default=False)
-
-CACHE_EMPTY_QUERYSETS = True
 
 ADMIN_REDIRECT_URL = config('ADMIN_REDIRECT_URL', default=None)
 


### PR DESCRIPTION
- Store bundles into cache (Redis in production) instead of S3.
- Merge fetch_pregenerated_snippets and fetch_render_snippets into one.

With this change the code gets simplified and big performance gains are expected
by removing the App -> S3 and CDN -> App -> S3 trips.

Also workers running in different regions will now return the same CDN URL
instead of a region specific URL

  New: https://snippets.cdn.mozilla.org/4/...
  Old: https://snippets.cdn.mozilla.org/us-west/bundles/bundle_....

which should improve the cache hit rate and distribute the load to different
regions better.

Added Etag support for the bundled snippets response.

Infra provisioning is simpler without the need of S3, except for the Admin App
which needs access to deploy files.

Tested on Tokyo for a short time and works as expected!

Before deploying:
 - [ ] Unset `SNIPPET_HTTP_MAX_AGE` from deis apps to get default value.
 - [ ] Unset `AWS_*` env variables from all hosts except from `snippets-admin`
 - [ ] Unset `FILE_STORAGE` env variable from all hosts except from `snippets-admin`
 - [ ] Update mozmeao/infra with new variables