### PR TITLE
Merge S3 buckets 

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -35,6 +35,8 @@ from snippets.base.managers import ClientMatchRuleManager, SnippetManager
 from snippets.base.util import hashfile
 
 
+ONE_DAY = 60 * 60 * 24
+
 JINJA_ENV = engines['backend']
 
 SNIPPET_JS_TEMPLATE_HASH = hashfile(
@@ -225,7 +227,7 @@ class SnippetBundle(object):
         if isinstance(bundle_content, unicode):
             bundle_content = bundle_content.encode('utf-8')
         default_storage.save(self.filename, ContentFile(bundle_content))
-        cache.set(self.cache_key, True, None)
+        cache.set(self.cache_key, True, ONE_DAY)
 
 
 class SnippetTemplate(models.Model):

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -22,6 +22,7 @@ from django.db.models.manager import Manager
 from django.template import engines
 from django.template.loader import render_to_string
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.functional import cached_property
 
 import django_mysql.models
 from jinja2 import Markup
@@ -136,7 +137,7 @@ class SnippetBundle(object):
         self.client = client
         self._snippets = None
 
-    @property
+    @cached_property
     def key(self):
         """A unique key for this bundle as a sha1 hexdigest."""
         # Key should consist of snippets that are in the bundle plus any

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -168,6 +168,18 @@ class SnippetBundle(object):
         return u'bundle_' + self.key
 
     @property
+    def cached(self):
+        if cache.get(self.cache_key):
+            return True
+
+        # Check if available on S3 already.
+        if default_storage.exists(self.filename):
+            cache.set(self.cache_key, True, ONE_DAY)
+            return True
+
+        return False
+
+    @property
     def expired(self):
         """
         If True, the code for this bundle should be re-generated before

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -455,7 +455,7 @@ class SnippetBundleTests(TestCase):
             'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
-        cache.set.assert_called_with(bundle.cache_key, True, None)
+        cache.set.assert_called_with(bundle.cache_key, True, ONE_DAY)
 
         # Check content of saved file.
         content_file = default_storage.save.call_args[0][1]
@@ -490,7 +490,7 @@ class SnippetBundleTests(TestCase):
             'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
-        cache.set.assert_called_with(bundle.cache_key, True, None)
+        cache.set.assert_called_with(bundle.cache_key, True, ONE_DAY)
 
         # Check content of saved file.
         content_file = default_storage.save.call_args[0][1]

--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -390,7 +390,7 @@ class FetchPregeneratedSnippetsTests(TestCase):
         with patch.object(views, 'SnippetBundle') as SnippetBundle:
             bundle = SnippetBundle.return_value
             bundle.url = '/foo/bar'
-            bundle.expired = True
+            bundle.cached = False
             response = views.fetch_pregenerated_snippets(self.request, **self.client_kwargs)
 
         self.assertEqual(response.status_code, 302)

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -102,7 +102,7 @@ def fetch_pregenerated_snippets(request, **kwargs):
     """
     client = Client(**kwargs)
     bundle = SnippetBundle(client)
-    if bundle.expired:
+    if not bundle.cached:
         bundle.generate()
         statsd.incr('bundle.generate')
     else:


### PR DESCRIPTION
Currently we're using different buckets and bucket locations for bundles depending on the region. This has some downsides:

 - Makes infrastructure and deployments of new cluster more complex. 
 - Reduces the benefits of CDN since different regions return different URLs (due to the different S3 origins) for the same content.

The upside of having the buckets geographically close to each cluster is lower upload times but since 35128394c7cfe88875fdc79fa9fd3ff6bb9bfcf1 we don't generate that many bundles.

This PR checks both Redis cache (first) and S3 (second) before generating a new bundle. If a bundle exists in S3 but not in Redis adds the key to the cache. 

It also reduces the key caching time down to one day to handle the auto-deletion of bundles in S3 better.

Need to change the following settings in `tokyo` and `frankfurt` after deploying to match `us-west`.

 - `AWS_STORAGE_BUCKET_NAME`
 - `AWS_S3_HOST`
 - `MEDIA_BUNDLES_ROOT`

Also run `./manage.py clear_cache` in 

 - [ ] tokyo
 - [ ] frankfurt 

after pushing. 
