### PR TITLE
[fix bug 1409700] Remove ALTERNATE_METRICS_URL.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -218,11 +218,6 @@ class SnippetBundle(object):
         current_firefox_version = (
             version_list(product_details.firefox_history_major_releases)[0].split('.', 1)[0])
 
-        metrics_url = settings.METRICS_URL
-        if ((settings.ALTERNATE_METRICS_URL and
-             self.client.channel in settings.ALTERNATE_METRICS_CHANNELS)):
-            metrics_url = settings.ALTERNATE_METRICS_URL
-
         template = 'base/fetch_snippets.jinja'
         if self.client.startpage_version == '5':
             template = 'base/fetch_snippets_as.jinja'
@@ -233,7 +228,6 @@ class SnippetBundle(object):
             'locale': self.client.locale,
             'settings': settings,
             'current_firefox_version': current_firefox_version,
-            'metrics_url': metrics_url,
         })
 
         if isinstance(bundle_content, unicode):

--- a/snippets/base/templates/base/includes/snippet.js
+++ b/snippets/base/templates/base/includes/snippet.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var SNIPPET_METRICS_SAMPLE_RATE = {{ settings.METRICS_SAMPLE_RATE }};
-var SNIPPET_METRICS_URL = '{{ metrics_url }}';
+var SNIPPET_METRICS_URL = '{{ settings.METRICS_URL }}';
 var ABOUTHOME_SHOWN_SNIPPET = null;
 var USER_COUNTRY = null;
 var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days

--- a/snippets/base/templates/base/includes/snippet_as.js
+++ b/snippets/base/templates/base/includes/snippet_as.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var SNIPPET_METRICS_SAMPLE_RATE = {{ settings.METRICS_SAMPLE_RATE }};
-var SNIPPET_METRICS_URL = '{{ metrics_url }}';
+var SNIPPET_METRICS_URL = '{{ settings.METRICS_URL }}';
 var ABOUTHOME_SHOWN_SNIPPET = null;
 var USER_COUNTRY = null;
 var GEO_CACHE_DURATION = 1000 * 60 * 60 * 24 * 30; // 30 days

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -452,7 +452,6 @@ class SnippetBundleTests(TestCase):
             'locale': 'fr',
             'settings': settings,
             'current_firefox_version': '45',
-            'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
         cache.set.assert_called_with(bundle.cache_key, True, ONE_DAY)
@@ -487,7 +486,6 @@ class SnippetBundleTests(TestCase):
             'locale': 'fr',
             'settings': settings,
             'current_firefox_version': '45',
-            'metrics_url': settings.METRICS_URL,
         })
         default_storage.save.assert_called_with(bundle.filename, ANY)
         cache.set.assert_called_with(bundle.cache_key, True, ONE_DAY)

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -125,11 +125,6 @@ def fetch_render_snippets(request, **kwargs):
     current_firefox_version = (
         version_list(product_details.firefox_history_major_releases)[0].split('.', 1)[0])
 
-    metrics_url = settings.METRICS_URL
-    if ((settings.ALTERNATE_METRICS_URL and
-         client.channel in settings.ALTERNATE_METRICS_CHANNELS)):
-        metrics_url = settings.ALTERNATE_METRICS_URL
-
     template = 'base/fetch_snippets.jinja'
 
     if client.startpage_version == '5':
@@ -140,7 +135,6 @@ def fetch_render_snippets(request, **kwargs):
         'client': client,
         'locale': client.locale,
         'current_firefox_version': current_firefox_version,
-        'metrics_url': metrics_url,
     })
 
     # ETag will be a hash of the response content.

--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -213,7 +213,7 @@ ANON_ALWAYS = True
 
 SNIPPET_BUNDLE_TIMEOUT = config('SNIPPET_BUNDLE_TIMEOUT', default=15 * 60, cast=int)  # 15 minutes
 
-METRICS_URL = config('METRICS_URL', default='https://snippets-stats.mozilla.org/foo.html')
+METRICS_URL = config('METRICS_URL', default='https://snippets-stats.moz.works/foo')
 METRICS_SAMPLE_RATE = config('METRICS_SAMPLE_RATE', default=0.1, cast=float)
 
 SITE_URL = config('SITE_URL', default='')
@@ -301,9 +301,6 @@ RAVEN_CONFIG = {
         'site': '.'.join(x for x in [DEIS_APP, DEIS_DOMAIN] if x),
     }
 }
-
-ALTERNATE_METRICS_URL = config('ALTERNATE_METRICS_URL', default=None)
-ALTERNATE_METRICS_CHANNELS = config('ALTERNATE_METRICS_CHANNELS', default='', cast=Csv())
 
 CACHALOT_ENABLED = config('CACHALOT_ENABLED', default=not DEBUG, cast=bool)
 CACHALOT_TIMEOUT = config('CACHALOT_TIMEOUT', default=300, cast=int)  # 300 = 5 minutes


### PR DESCRIPTION
Remove ALTERNATE_METRICS_URL.
Default METRICS_URL to https://snippets-stats.moz.works/foo

- After pushing remove ALTERNATE_METRICS_URL from 
  - [ ] US-West Stage
  - [ ] US-West Admin
  - [ ] US-West Prod
  - [ ] Tokyo Prod
  - [ ] Frankfurt Prod
