### PR TITLE
 [bug 1408981] Update bundle key generation.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -41,6 +41,7 @@ SNIPPET_FETCH_TEMPLATE_HASH = hashlib.sha1(
     render_to_string(
         'base/fetch_snippets.jinja',
         {
+            'date': '',
             'snippet_ids': [],
             'snippets_json': '',
             'locale': 'xx',
@@ -54,6 +55,7 @@ SNIPPET_FETCH_TEMPLATE_AS_HASH = hashlib.sha1(
     render_to_string(
         'base/fetch_snippets_as.jinja',
         {
+            'date': '',
             'snippet_ids': [],
             'snippets_json': '',
             'locale': 'xx',

--- a/snippets/base/templates/base/fetch_snippets.jinja
+++ b/snippets/base/templates/base/fetch_snippets.jinja
@@ -1,7 +1,11 @@
 {% include 'base/includes/snippet.css' %}
 <script type="text/javascript">
  //<![CDATA[
- // Generated on {{ utcnow() }}
+{#
+ The date variable gets populated when we calculate the template hash for caching
+ and gets the default utcnow() time otherwise.
+#}
+ // Generated on {{ date|default(utcnow()) }}
  // Included snippets:
      {% for id in snippet_ids %}
  //  - {{ id }}

--- a/snippets/base/templates/base/fetch_snippets_as.jinja
+++ b/snippets/base/templates/base/fetch_snippets_as.jinja
@@ -2,7 +2,11 @@
   {% include 'base/includes/snippet_as.css' %}
 </style>
 <script type="application/javascript">
- // Generated on {{ utcnow() }}
+{#
+ The date variable gets populated when we calculate the template hash for caching
+ and gets the default utcnow() time otherwise.
+#}
+ // Generated on {{ date|default(utcnow()) }}
  // Included snippets:
  {% for id in snippet_ids %}
  //  - {{ id }}

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -417,18 +417,6 @@ class SnippetBundleTests(TestCase):
 
         self.assertNotEqual(bundle1.key, bundle2.key)
 
-    def test_key_name(self):
-        """
-        bundle.key must be different between bundles if they have
-        different names.
-        """
-        client1 = self._client(name='firefox')
-        client2 = self._client(name='firefox-test')
-        bundle1 = SnippetBundle(client1)
-        bundle2 = SnippetBundle(client2)
-
-        self.assertNotEqual(bundle1.key, bundle2.key)
-
     def test_key_equal(self):
         client1 = self._client(locale='en-US', startpage_version='4')
         client2 = self._client(locale='en-US', startpage_version='4')


### PR DESCRIPTION
 - Use only startpage_version and locale used in the templates.

 - Include in the key either template for AS or for about:home, so that changes
   in one template does not affect the cached keys of the other.