### PR TITLE
Remove xfail for post-57 release channel

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -38,12 +38,7 @@ def test_response_codes(base_url, version, channel):
     assert r.status_code in (requests.codes.ok, requests.codes.no_content)
 
 
-@pytest.mark.parametrize(('channel'), [
-    'aurora',
-    'beta',
-    pytest.param('release', marks=pytest.mark.xfail(
-        'mozilla' in pytest.config.getoption('base_url'),
-        reason='Activity Stream will be available after Firefox 57'))])
+@pytest.mark.parametrize(('channel'), ['aurora', 'beta', 'release'])
 def test_activity_stream(base_url, channel):
     url = URL_TEMPLATE.format(base_url, '5', channel)
     soup = _parse_response(_get_redirect(url).content)


### PR DESCRIPTION
@davehunt / @glogiotatidis r?

snippets.prod has been failing for 15 hours[0], due to the xfail for the release channel now passing.

I've tested my patch to remove the xfail against both prod[1] and staging[2], and all is well.

[0] https://fx-test-jenkins.stage.mozaws.net/job/snippets.prod/42247/
[1] https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/snippets.adhoc/26/consoleFull
[2] https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/snippets.adhoc/27/console