### PR TITLE
Return 200 with empty content instead of 204.

### DIFF
--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -348,7 +348,8 @@ class FetchSnippetsTests(TestCase):
             bundle.empty = True
             response = views.fetch_snippets(self.request, **self.client_kwargs)
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, '')
 
     @patch('snippets.base.views.Client', wraps=Client)
     def test_client_construction(self, ClientMock):

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -104,7 +104,9 @@ def fetch_snippets(request, **kwargs):
     bundle = SnippetBundle(client)
     if bundle.empty:
         statsd.incr('bundle.empty')
-        return HttpResponse(status=204)
+        # This is not a 204 because Activity Stream expects content, even if
+        # it's empty.
+        return HttpResponse(status=200, content='')
     elif bundle.cached:
         statsd.incr('bundle.cached')
     else:


### PR DESCRIPTION
AS will not update stored snippets' content on 204. Using 200 with empty content
works fine.