### PR TITLE
Update ancient user-agent string to latest

### DIFF
--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 REQUESTS_TIMEOUT = 20
 URL_TEMPLATE = '{}/{}/Firefox/default/default/default/en-US/{}/default/default/default/'
 
-_user_agent_firefox = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:10.0.1) Gecko/20100101 Firefox/10.0.1'
+_user_agent_firefox = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0'
 
 
 def _get_redirect(url, user_agent=_user_agent_firefox, locale='en-US'):


### PR DESCRIPTION
Self-explanatory, I hope; @davehunt @glogiotatidis @jgmize r?

Ad-hoc job (https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/snippets.adhoc/6613/console) results: 

```
Started by user sdonner@mozilla.com
Checking out git ${REPOSITORY} into /var/lib/jenkins/jobs/snippets.adhoc/workspace@script to read tests/Jenkinsfile
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/snippets-service.git
 > git init /var/lib/jenkins/jobs/snippets.adhoc/workspace@script # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse origin/update-user-agent^{commit} # timeout=10
Checking out Revision 05b77c348aeacc238f756ebf673bba03a30d1fa0 (origin/update-user-agent)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 05b77c348aeacc238f756ebf673bba03a30d1fa0
Commit message: "Update ancient user-agent string to latest"
First time build. Skipping changelog.
[Pipeline] library
Loading library fxtest@1.10
 > git rev-parse --is-inside-work-tree # timeout=10
Setting origin to https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching origin...
Fetching upstream changes from origin
 > git --version # timeout=10
 > git fetch --tags --progress origin +refs/heads/*:refs/remotes/origin/*
 > git rev-parse 1.10^{commit} # timeout=10
Wiping out workspace first.
Cloning the remote Git repository
Cloning with configured refspecs honoured and without tags
Cloning repository https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > git init /var/lib/jenkins/jobs/snippets.adhoc/workspace@libs/fxtest # timeout=10
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > git --version # timeout=10
 > git fetch --no-tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching without tags
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > git fetch --no-tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
Checking out Revision 81225a8aa34482806f973c837580286c7e614d24 (1.10)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 81225a8aa34482806f973c837580286c7e614d24
Commit message: "Added release notes for v1.10"
 > git rev-list 81225a8aa34482806f973c837580286c7e614d24 # timeout=10
[Pipeline] node
Running on centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net in /home/jenkins/workspace/snippets.adhoc
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/snippets-service.git
 > git init /home/jenkins/workspace/snippets.adhoc # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse origin/update-user-agent^{commit} # timeout=10
Checking out Revision 05b77c348aeacc238f756ebf673bba03a30d1fa0 (origin/update-user-agent)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 05b77c348aeacc238f756ebf673bba03a30d1fa0
Commit message: "Update ancient user-agent string to latest"
[Pipeline] }
[Pipeline] // stage
[Pipeline] withEnv
[Pipeline] {
[Pipeline] ansiColor
[Pipeline] {
[Pipeline] timestamps
[Pipeline] {
[Pipeline] timeout
Timeout set to expire in 5 min 0 sec
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Lint)
[Pipeline] node
Running on centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net in /home/jenkins/workspace/snippets.adhoc@2
[Pipeline] {
[Pipeline] checkout
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/snippets-service.git
 > git init /home/jenkins/workspace/snippets.adhoc@2 # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse origin/update-user-agent^{commit} # timeout=10
Checking out Revision 05b77c348aeacc238f756ebf673bba03a30d1fa0 (origin/update-user-agent)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 05b77c348aeacc238f756ebf673bba03a30d1fa0
Commit message: "Update ancient user-agent string to latest"
[Pipeline] withEnv
[Pipeline] {
[Pipeline] readFile
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ docker build -t 55453da9e95dbf332a07e7a7a38bf65b333f24b6 -f tests/Dockerfile tests
Sending build context to Docker daemon 14.34 kB

Step 1 : FROM python:2-alpine3.7
 ---> 8a6404845d59
Step 2 : WORKDIR /src
 ---> Using cache
 ---> 675deb258a7f
Step 3 : COPY requirements.txt /src
 ---> Using cache
 ---> 3c3e357200cc
Step 4 : RUN pip install -r requirements.txt
 ---> Using cache
 ---> 051691e8ae95
Step 5 : COPY . /src
 ---> 9909a57df923
Removing intermediate container d236021e9b23
Step 6 : CMD pytest
 ---> Running in f368f918ab34
 ---> 55325a5e0f13
Removing intermediate container f368f918ab34
Successfully built 55325a5e0f13
[Pipeline] dockerFingerprintFrom
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ docker inspect -f . 55453da9e95dbf332a07e7a7a38bf65b333f24b6
.
[Pipeline] withDockerContainer
centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net does not seem to be running inside a container
$ docker run -t -d -u 1036:1036 -w /home/jenkins/workspace/snippets.adhoc@2 -v /home/jenkins/workspace/snippets.adhoc@2:/home/jenkins/workspace/snippets.adhoc@2:rw,z -v /home/jenkins/workspace/snippets.adhoc@2@tmp:/home/jenkins/workspace/snippets.adhoc@2@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** --entrypoint cat 55453da9e95dbf332a07e7a7a38bf65b333f24b6
[Pipeline] {
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ flake8 tests/
[Pipeline] }
$ docker stop --time=1 f1a77be9091b0055f42b869014ad2901be1bbac8f222167e582f0a06060f1b7e
$ docker rm -f f1a77be9091b0055f42b869014ad2901be1bbac8f222167e582f0a06060f1b7e
[Pipeline] // withDockerContainer
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Test)
[Pipeline] node
Running on centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net in /home/jenkins/workspace/snippets.adhoc@2
[Pipeline] {
[Pipeline] checkout
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/snippets-service.git
 > git init /home/jenkins/workspace/snippets.adhoc@2 # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git --version # timeout=10
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
 > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > git config remote.origin.url https://github.com/stephendonner/snippets-service.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/snippets-service.git
 > git fetch --tags --progress https://github.com/stephendonner/snippets-service.git +refs/heads/*:refs/remotes/origin/*
 > git rev-parse origin/update-user-agent^{commit} # timeout=10
Checking out Revision 05b77c348aeacc238f756ebf673bba03a30d1fa0 (origin/update-user-agent)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 05b77c348aeacc238f756ebf673bba03a30d1fa0
Commit message: "Update ancient user-agent string to latest"
[Pipeline] withEnv
[Pipeline] {
[Pipeline] readFile
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ docker build -t 55453da9e95dbf332a07e7a7a38bf65b333f24b6 -f tests/Dockerfile tests
Sending build context to Docker daemon 14.34 kB

Step 1 : FROM python:2-alpine3.7
 ---> 8a6404845d59
Step 2 : WORKDIR /src
 ---> Using cache
 ---> 675deb258a7f
Step 3 : COPY requirements.txt /src
 ---> Using cache
 ---> 3c3e357200cc
Step 4 : RUN pip install -r requirements.txt
 ---> Using cache
 ---> 051691e8ae95
Step 5 : COPY . /src
 ---> Using cache
 ---> 9909a57df923
Step 6 : CMD pytest
 ---> Using cache
 ---> 55325a5e0f13
Successfully built 55325a5e0f13
[Pipeline] dockerFingerprintFrom
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ docker inspect -f . 55453da9e95dbf332a07e7a7a38bf65b333f24b6
.
[Pipeline] withDockerContainer
centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net does not seem to be running inside a container
$ docker run -t -d -u 1036:1036 -w /home/jenkins/workspace/snippets.adhoc@2 -v /home/jenkins/workspace/snippets.adhoc@2:/home/jenkins/workspace/snippets.adhoc@2:rw,z -v /home/jenkins/workspace/snippets.adhoc@2@tmp:/home/jenkins/workspace/snippets.adhoc@2@tmp:rw,z -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** -e ******** --entrypoint cat 55453da9e95dbf332a07e7a7a38bf65b333f24b6
[Pipeline] {
[Pipeline] withCredentials
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] sh
[snippets.adhoc@2] Running shell script
+ pytest -n=auto --color=yes --junit-xml=tests/results/junit.xml --html=tests/results/index.html --self-contained-html --log-raw=tests/results/raw.txt --log-tbpl=tests/results/tbpl.txt tests
============================= test session starts ==============================
platform linux2 -- Python 2.7.14, pytest-3.4.2, py-1.5.2, pluggy-0.6.0 -- /usr/local/bin/python
cachedir: tests/.pytest_cache
metadata: {'BUILD_ID': '6613', 'Base URL': 'https://snippets.allizom.org', 'BUILD_NUMBER': '6613', 'GIT_COMMIT': '05b77c348aeacc238f756ebf673bba03a30d1fa0', 'Python': '2.7.14', 'BUILD_URL': 'https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/snippets.adhoc/6613/', 'EXECUTOR_NUMBER': '8', 'NODE_NAME': 'centos7-1-qatest-slave.fxtestpreprod.jenkins.stage.mozaws.net', 'BUILD_TAG': 'jenkins-snippets.adhoc-6613', 'Platform': 'Linux-3.10.0-514.16.1.el7.x86_64-x86_64-with', 'JENKINS_URL': 'https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/', 'GIT_URL': '${REPOSITORY}', 'WORKSPACE': '/home/jenkins/workspace/snippets.adhoc@2', 'Plugins': {'xdist': '1.22.2', 'mozlog': '3.7', 'html': '1.16.1', 'forked': '0.2', 'base-url': '1.4.1', 'metadata': '1.6.0'}, 'Packages': {'py': '1.5.2', 'pytest': '3.4.2', 'pluggy': '0.6.0'}, 'JOB_NAME': 'snippets.adhoc', 'GIT_BRANCH': 'origin/update-user-agent'}
baseurl: https://snippets.allizom.org
rootdir: /home/jenkins/workspace/snippets.adhoc@2/tests, inifile: setup.cfg
plugins: xdist-1.22.2, metadata-1.6.0, html-1.16.1, forked-0.2, base-url-1.4.1, mozlog-3.7
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I

[gw0] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw1] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw2] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw3] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw4] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw5] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw6] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw7] linux2 Python 2.7.14 cwd: /home/jenkins/workspace/snippets.adhoc@2

[gw1] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw0] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw2] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw3] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw4] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw5] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw7] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]

[gw6] Python 2.7.14 (default, Jan 10 2018, 05:35:30)  -- [GCC 6.4.0]
gw0 [10] / gw1 [10] / gw2 [10] / gw3 [10] / gw4 [10] / gw5 [10] / gw6 [10] / gw7 [10]

scheduling tests via LoadScheduling

tests/test_snippets.py::test_that_snippets_are_well_formed_xml[aurora] 
tests/test_snippets.py::test_response_codes[aurora-activitystream] 
tests/test_snippets.py::test_response_codes[release-legacy] 
tests/test_snippets.py::test_response_codes[beta-legacy] 
tests/test_snippets.py::test_response_codes[aurora-legacy] 
tests/test_snippets.py::test_legacy 
tests/test_snippets.py::test_response_codes[beta-activitystream] 
tests/test_snippets.py::test_response_codes[release-activitystream] 
[gw0] [ 10%] PASSED tests/test_snippets.py::test_response_codes[aurora-activitystream] 
tests/test_snippets.py::test_that_snippets_are_well_formed_xml[release] 
[gw3] [ 20%] PASSED tests/test_snippets.py::test_legacy 
[gw1] [ 30%] PASSED tests/test_snippets.py::test_response_codes[release-activitystream] 
[gw5] [ 40%] PASSED tests/test_snippets.py::test_response_codes[beta-activitystream] 
[gw6] [ 50%] PASSED tests/test_snippets.py::test_that_snippets_are_well_formed_xml[aurora] 
[gw7] [ 60%] PASSED tests/test_snippets.py::test_response_codes[release-legacy] 
[gw4] [ 70%] PASSED tests/test_snippets.py::test_response_codes[aurora-legacy] 
tests/test_snippets.py::test_that_snippets_are_well_formed_xml[beta] 
Post stage
[gw2] [ 80%] PASSED tests/test_snippets.py::test_response_codes[beta-legacy] 
[gw0] [ 90%] PASSED tests/test_snippets.py::test_that_snippets_are_well_formed_xml[release] 
[gw4] [100%] PASSED tests/test_snippets.py::test_that_snippets_are_well_formed_xml[beta] 

 generated xml file: /home/jenkins/workspace/snippets.adhoc@2/tests/results/junit.xml 
 generated html file: /home/jenkins/workspace/snippets.adhoc@2/tests/results/index.html 
========================== 10 passed in 3.58 seconds ===========================
[Pipeline] stash
Stashed 4 file(s)
[Pipeline] archiveArtifacts
Archiving artifacts
[Fast Archiver] Compressed 241.67 KB of artifacts by 39.7% relative to #6612
[Pipeline] junit
Recording test results
[Pipeline] step
Publish artifacts to S3 Bucket Build is still running
Publish artifacts to S3 Bucket Using S3 profile: fx-test-jenkins-s3-publisher
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-activedata/jenkins-snippets.adhoc-6613, file=raw.txt region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
[Pipeline] findFiles
[Pipeline] step
Publish artifacts to S3 Bucket Build is still running
Publish artifacts to S3 Bucket Using S3 profile: fx-test-jenkins-s3-publisher
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613, file=index.html region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613, file=junit.xml region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613, file=raw.txt region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613, file=tbpl.txt region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
[Pipeline] findFiles
[Pipeline] step
Publish artifacts to S3 Bucket Build is still running
Publish artifacts to S3 Bucket Using S3 profile: fx-test-jenkins-s3-publisher
Publish artifacts to S3 Bucket bucket=net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613, file=tbpl.txt region=us-east-1, will be uploaded from slave=false managed=false , server encryption false
[Pipeline] findFiles
[Pipeline] echo
Published payload to Pulse on exchange/****/jobs with routing key ****.snippets-service.
[Pipeline] echo
{"taskId":"4338c873-1856-40b8-850f-d3e5337b5472","buildSystem":"qa-preprod-master","origin":{"kind":"github.com","project":"snippets-service","revision":"05b77c348aeacc238f756ebf673bba03a30d1fa0"},"display":{"jobSymbol":"e2e","jobName":"End-to-end integration tests","groupSymbol":"j","groupName":"Executed by Jenkins"},"state":"completed","result":"success","jobKind":"test","timeScheduled":"2018-04-03T06:35:52Z","timeStarted":"2018-04-03T06:35:52Z","timeCompleted":"2018-04-03T06:36:14Z","reason":"scheduled","productName":"snippets-service","buildMachine":{"name":"qa-preprod-master","platform":"linux-3-10-0-514-16-1-el7-x86_64-amd64","os":"linux","architecture":"amd64"},"runMachine":{"name":"qa-preprod-master","platform":"linux-3-10-0-514-16-1-el7-x86_64-amd64","os":"linux","architecture":"amd64"},"jobInfo":{"links":[{"url":"https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/snippets.adhoc/6613/","linkText":"jenkins-snippets.adhoc-6613","label":"build"},{"url":"https://s3.amazonaws.com/net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613/index.html","linkText":"index.html","label":"artifact uploaded"},{"url":"https://s3.amazonaws.com/net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613/junit.xml","linkText":"junit.xml","label":"artifact uploaded"},{"url":"https://s3.amazonaws.com/net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613/raw.txt","linkText":"raw.txt","label":"artifact uploaded"},{"url":"https://s3.amazonaws.com/net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613/tbpl.txt","linkText":"tbpl.txt","label":"artifact uploaded"}]},"logs":[{"url":"https://s3.amazonaws.com/net-mozaws-stage-fx-test-treeherder/jenkins-snippets.adhoc-6613/tbpl.txt","name":"buildbot_text"}],"version":1}
[Pipeline] echo
Results will be available to view at https://treeherder.mozilla.org/#/jobs?repo=snippets-service&revision=05b77c348aeacc238f756ebf673bba03a30d1fa0
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withCredentials
[Pipeline] }
$ docker stop --time=1 08c79bb23062f830c8a52f73a17431501082c9184ff38052afe31cbad0d5df68
$ docker rm -f 08c79bb23062f830c8a52f73a17431501082c9184ff38052afe31cbad0d5df68
[Pipeline] // withDockerContainer
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Declarative: Post Actions)
[Pipeline] unstash
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
[Pipeline] // timestamps
[Pipeline] }
[Pipeline] // ansiColor
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```