### PR TITLE
Don't verify SSL cert during acceptance tests.

### DIFF
--- a/bin/acceptance-tests.sh
+++ b/bin/acceptance-tests.sh
@@ -15,7 +15,7 @@ URLS=(
 
 function check_http_code {
     echo -n "Checking URL ${1} "
-    curl -L -s -o /dev/null -I -w "%{http_code}" $1 | grep ${2:-200} > /dev/null
+    curl -k -H "Host: snippets.mozilla.com" -L -s -o /dev/null -I -w "%{http_code}" $1 | grep ${2:-200} > /dev/null
     if [ $? -eq 0 ];
     then
         echo "OK"


### PR DESCRIPTION
Current infra setup uses a SSL cert that it's only valid for
snippets.mozilla.com and not for the cluster
URL (snippets-prod.oregon-b.moz.works). Add -k curl flag to skip cert
validation.