### PR TITLE
[Issue #353] Publish button

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -432,3 +432,6 @@ django-quickedit-ng==0.2.0 \
     --hash=sha256:be09d4ffd2c56b79a2ec167f125ef4dbd779c66dbf12910bdb1a856399e34de6
 django-admin-list-filter-dropdown==1.0.1 \
     --hash=sha256:e79856c790224c5a466bf222bb99d5a2a73f5e4ed954cb1b6fcc4a52f078b3b9
+django-object-actions==1.0.0 \
+    --hash=sha256:54151c8760cc3dc8627fdd0e66e5b1ae5391625756d7b301b939155a74f231a6 \
+    --hash=sha256:ac764e1fea91150160a9690c1cb5ae88d320da89cd06c65ec24c92247fb0762c

--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -114,10 +114,7 @@ class BaseSnippetAdmin(AdminAdvancedFiltersMixin, VersionAdmin,
         'locale_list',
         'modified',
     )
-    list_editable = (
-        'published',
-    )
-    readonly_fields = ('created', 'modified', 'uuid')
+    readonly_fields = ('created', 'modified', 'uuid', 'published')
     save_on_top = True
     save_as = True
 

--- a/snippets/base/admin.py
+++ b/snippets/base/admin.py
@@ -10,6 +10,7 @@ from django.utils.encoding import force_text
 from advanced_filters.admin import AdminAdvancedFiltersMixin
 from django_ace import AceWidget
 from django_admin_listfilter_dropdown.filters import RelatedDropdownFilter
+from django_object_actions import DjangoObjectActions
 from django_statsd.clients import statsd
 from jinja2.meta import find_undeclared_variables
 from reversion.admin import VersionAdmin
@@ -135,14 +136,6 @@ class BaseSnippetAdmin(AdminAdvancedFiltersMixin, VersionAdmin,
         ('locales__name', 'Language'),
     )
 
-    def change_view(self, request, *args, **kwargs):
-        if request.method == 'POST' and '_saveasnew' in request.POST:
-            # Always saved cloned snippets as un-published.
-            post_data = request.POST.copy()
-            post_data['published'] = u'off'
-            request.POST = post_data
-        return super(BaseSnippetAdmin, self).change_view(request, *args, **kwargs)
-
     def locale_list(self, obj):
         num_locales = obj.locales.count()
         locales = obj.locales.all()[:3]
@@ -152,10 +145,7 @@ class BaseSnippetAdmin(AdminAdvancedFiltersMixin, VersionAdmin,
         return active_locales
 
 
-class SnippetAdmin(QuickEditAdmin, BaseSnippetAdmin):
-    def get_changelist_form(self, request, **kwargs):
-        return forms.SnippetChangeListForm
-
+class SnippetAdmin(DjangoObjectActions, QuickEditAdmin, BaseSnippetAdmin):
     form = forms.SnippetAdminForm
     readonly_fields = BaseSnippetAdmin.readonly_fields + ('preview_url',)
     search_fields = ('name', 'client_match_rules__description',
@@ -178,6 +168,13 @@ class SnippetAdmin(QuickEditAdmin, BaseSnippetAdmin):
     )
     filter_horizontal = (BaseSnippetAdmin.filter_horizontal +
                          ('exclude_from_search_providers', 'client_match_rules'))
+
+    actions = (duplicate_snippets_action,)
+
+    # All Change actions must be defined here but which ones are finally
+    # displayed to the use is controlled by the get_change_actions method,
+    # depending of the attributes of the obj and the permissions of the user.
+    change_actions = ('publish_object', 'unpublish_object')
 
     fieldsets = (
         (None, {'fields': ('name', 'published', 'campaign', 'preview_url', 'created', 'modified')}),
@@ -237,12 +234,14 @@ class SnippetAdmin(QuickEditAdmin, BaseSnippetAdmin):
         }),
     )
 
-    actions = (duplicate_snippets_action,)
-
     class Media:
         css = {
             'all': ('css/admin.css',)
         }
+        js = ('js/admin-publish.js',)
+
+    def get_changelist_form(self, request, **kwargs):
+        return forms.SnippetChangeListForm
 
     def save_model(self, request, obj, form, change):
         statsd.incr('save.snippet')
@@ -262,6 +261,33 @@ class SnippetAdmin(QuickEditAdmin, BaseSnippetAdmin):
     def queryset(self, request):
         return (super(SnippetAdmin, self)
                 .queryset(request).prefetch_related('locales').select_related('template'))
+
+    def publish_object(self, request, obj):
+        self.message_user(request, 'Published snippet')
+        obj.published = True
+        obj.save()
+    publish_object.label = 'Publish'
+    publish_object.short_description = 'Publish this snippet'
+
+    def unpublish_object(self, request, obj):
+        self.message_user(request, 'Unpublished snippet')
+        obj.published = False
+        obj.save()
+    unpublish_object.label = 'Unpublish'
+    unpublish_object.short_description = 'Unpublish this snippet'
+
+    def get_change_actions(self, request, object_id, form_url):
+        """Dynamically define object change actions based on object properties."""
+        actions = super(SnippetAdmin, self).get_change_actions(request, object_id, form_url)
+        actions = list(actions)
+
+        obj = self.model.objects.get(pk=object_id)
+        if obj.published:
+            actions.remove('publish_object')
+        else:
+            actions.remove('unpublish_object')
+
+        return actions
 
 
 class ClientMatchRuleAdmin(VersionAdmin, admin.ModelAdmin):

--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -167,7 +167,7 @@ class SnippetChangeListForm(forms.ModelForm):
             self.body_variable = (instance.template
                                   .variable_set.get(type=SnippetTemplateVariable.BODY).name)
         except SnippetTemplateVariable.DoesNotExist:
-            self.fields['body'].published = False
+            self.fields['body'].disabled = True
         else:
             text = instance.dict_data[self.body_variable]
             self.fields['body'].initial = text
@@ -280,7 +280,7 @@ class SnippetAdminForm(BaseSnippetAdminForm):
 
     class Meta:
         model = Snippet
-        fields = ('name', 'template', 'data', 'published', 'countries',
+        fields = ('name', 'template', 'data', 'countries',
                   'publish_start', 'publish_end', 'on_release', 'on_beta',
                   'on_aurora', 'on_nightly', 'on_esr', 'on_startpage_1',
                   'on_startpage_2', 'on_startpage_3', 'on_startpage_4',

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -557,6 +557,10 @@ class Snippet(SnippetBaseModel):
     def save(self, *args, **kwargs):
         if self.client_options is None:
             self.client_options = {}
+        # Save duplicated or save-as-new snippet un-published
+        if self.id is None:
+            self.published = False
+
         return super(Snippet, self).save(*args, **kwargs)
 
 

--- a/snippets/base/static/css/admin.css
+++ b/snippets/base/static/css/admin.css
@@ -17,3 +17,11 @@ td.field-description .vLargeTextField {
     width: 60em;
     height: 3em;
 }
+
+.object-tools [data-tool-name="publish_object"] a {
+    background: green;
+}
+
+.object-tools [data-tool-name="unpublish_object"] a {
+    background: #a41515;
+}

--- a/snippets/base/static/js/admin-publish.js
+++ b/snippets/base/static/js/admin-publish.js
@@ -1,0 +1,11 @@
+django.jQuery(document).ready(function() {
+    django.jQuery('[data-tool-name="publish_object"]').on("click", function(event) {
+        function confirmation() {
+            let answer = confirm("Really publish Snippet?");
+            if (!answer) {
+                event.preventDefault();
+            }
+        }
+        confirmation();
+    });
+});

--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -39,6 +39,16 @@ class BaseSnippetFactory(factory.django.DjangoModelFactory):
     on_release = True
 
     @factory.post_generation
+    def published(self, create, extracted, **kwargs):
+        """New snippets are forcefully save as unpublished, publish them."""
+        if not create:
+            return
+
+        self.published = True
+        if extracted is not None:
+            self.published = extracted
+
+    @factory.post_generation
     def client_match_rules(self, create, extracted, **kwargs):
         if not create:
             return

--- a/snippets/settings.py
+++ b/snippets/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     'watchman',
     'quickedit',
     'django_admin_listfilter_dropdown',
+    'django_object_actions',
 
     # Django apps
     'django.contrib.admin',


### PR DESCRIPTION
Convert `published` from a check-box to a button with confirmation pop-up before publishing. 

![image](https://user-images.githubusercontent.com/584352/40421828-dfdb7294-5e95-11e8-9862-3ce0c315fa46.png)


Will extend with permission checking