### PR TITLE
Add isDefaultBrowser JEXL Targeting 

### DIFF
--- a/snippets/base/admin/adminmodels.py
+++ b/snippets/base/admin/adminmodels.py
@@ -105,6 +105,8 @@ class UploadedFileAdmin(admin.ModelAdmin):
 
 
 class ASRSnippetAdmin(admin.ModelAdmin):
+    form = forms.ASRSnippetAdminForm
+
     list_display_links = (
         'id',
         'name',
@@ -144,11 +146,6 @@ class ASRSnippetAdmin(admin.ModelAdmin):
         }),
     )
 
-    def get_form(self, request, obj=None, **kwargs):
-        form = super(ASRSnippetAdmin, self).get_form(request, obj, **kwargs)
-        form.current_user = request.user
-        return form
-
     def save_model(self, request, obj, form, change):
         obj.creator = request.user
         statsd.incr('save.asrsnippet')
@@ -179,7 +176,8 @@ class CampaignAdmin(admin.ModelAdmin):
 
 
 class TargetAdmin(admin.ModelAdmin):
-    readonly_fields = ('created', 'modified', 'creator',)
+    form = forms.TargetAdminForm
+    readonly_fields = ('created', 'modified', 'creator', 'jexl_expr')
 
     fieldsets = (
         ('ID', {'fields': ('name',)}),
@@ -187,8 +185,11 @@ class TargetAdmin(admin.ModelAdmin):
             'description': 'What channels will this snippet be available in?',
             'fields': (('on_release', 'on_beta', 'on_aurora', 'on_nightly', 'on_esr'),)
         }),
+        ('Targeting', {
+            'fields': ('filtr_is_default_browser', )
+        }),
         ('Other Info', {
-            'fields': ('creator', ('created', 'modified')),
+            'fields': ('creator', ('created', 'modified'), 'jexl_expr'),
         }),
     )
 

--- a/snippets/base/admin/fields.py
+++ b/snippets/base/admin/fields.py
@@ -1,0 +1,28 @@
+from django.forms import ChoiceField, MultipleChoiceField
+
+
+class MultipleChoiceFieldCSV(MultipleChoiceField):
+    # To be used with in snippets.base.forms.SnippetAdminForm and in
+    # combination with DynamicField. We don't directly save() this field in the
+    # database so get_prep_value has not been implemented.
+
+    def prepare_value(self, value):
+        value = super(MultipleChoiceFieldCSV, self).prepare_value(value)
+        if not isinstance(value, list):
+            value = value.split(';')
+        return value
+
+    def clean(self, value):
+        value = super(MultipleChoiceFieldCSV, self).clean(value)
+        return ';'.join(value)
+
+
+class JEXLChoiceField(ChoiceField):
+    def __init__(self, attr_name, *args, **kwargs):
+        self.attr_name = attr_name
+        return super().__init__(*args, **kwargs)
+
+    def to_jexl(self, value):
+        if value:
+            return '{} == {}'.format(self.attr_name, value)
+        return None

--- a/snippets/base/fields.py
+++ b/snippets/base/fields.py
@@ -1,8 +1,6 @@
-import re
-
-from django.core.exceptions import ValidationError
 from django.db import models
-from django.forms import MultipleChoiceField
+
+from snippets.base.validators import validate_regex
 
 
 class RegexField(models.CharField):
@@ -12,28 +10,3 @@ class RegexField(models.CharField):
                   'validators': [validate_regex]}
         myargs.update(kwargs)
         return super(RegexField, self).__init__(*args, **myargs)
-
-
-class MultipleChoiceFieldCSV(MultipleChoiceField):
-    # To be used with in snippets.base.forms.SnippetAdminForm and in
-    # combination with DynamicField. We don't directly save() this field in the
-    # database so get_prep_value has not been implemented.
-
-    def prepare_value(self, value):
-        value = super(MultipleChoiceFieldCSV, self).prepare_value(value)
-        if not isinstance(value, list):
-            value = value.split(';')
-        return value
-
-    def clean(self, value):
-        value = super(MultipleChoiceFieldCSV, self).clean(value)
-        return ';'.join(value)
-
-
-def validate_regex(regex_str):
-    if regex_str.startswith('/'):
-        try:
-            re.compile(regex_str[1:-1])
-        except re.error as exp:
-            raise ValidationError(str(exp))
-    return regex_str

--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -568,7 +568,7 @@ class TargetAdminForm(forms.ModelForm):
         if self.instance and self.instance.jexl:
             for name, field in self.fields.items():
                 if name.startswith('filtr_'):
-                    field.initial = self.instance.jexl.get(name[6:])
+                    field.initial = self.instance.jexl.get(name)
 
     def save(self, *args, **kwargs):
         jexl = {}
@@ -576,7 +576,7 @@ class TargetAdminForm(forms.ModelForm):
 
         for name, field in self.fields.items():
             if name.startswith('filtr_'):
-                jexl[name[6:]] = self.cleaned_data[name]
+                jexl[name] = self.cleaned_data[name]
                 jexl_expr_array.append(field.to_jexl(self.cleaned_data[name]))
         self.instance.jexl = jexl
         self.instance.jexl_expr = ' && '.join([x for x in jexl_expr_array if x])

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -561,11 +561,7 @@ class Target(models.Model):
     def __str__(self):
         return self.name
 
-    def render_jexl(self):
-        return ' && '.join([expr for expr in self.jexl.values() if expr])
-
     def save(self, *args, **kwargs):
-        self.jexl_expr = self.render_jexl()
         super().save(*args, **kwargs)
 
 

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -552,7 +552,12 @@ class Target(models.Model):
     client_match_rules = models.ManyToManyField(
         ClientMatchRule, blank=True, verbose_name='Client Match Rules')
 
-    jexl = django_mysql.models.DynamicField(default={})
+    jexl = django_mysql.models.DynamicField(
+        default={},
+        spec={
+            'filtr_is_default_browser': str,
+        }
+    )
     jexl_expr = models.TextField(blank=True, default='')
 
     class Meta:

--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -119,7 +119,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
 
 class TargetFactory(factory.django.DjangoModelFactory):
-    name = factory.Sequence(lambda n: 'Search Provider {0}'.format(n))
+    name = factory.Sequence(lambda n: 'Target {0}'.format(n))
     creator = factory.SubFactory(UserFactory)
     on_release = True
 

--- a/snippets/base/tests/__init__.py
+++ b/snippets/base/tests/__init__.py
@@ -109,3 +109,19 @@ class SearchProviderFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = models.SearchProvider
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    username = factory.Sequence(lambda n: 'User {0}'.format(n))
+
+    class Meta:
+        model = 'auth.User'
+
+
+class TargetFactory(factory.django.DjangoModelFactory):
+    name = factory.Sequence(lambda n: 'Search Provider {0}'.format(n))
+    creator = factory.SubFactory(UserFactory)
+    on_release = True
+
+    class Meta:
+        model = models.Target

--- a/snippets/base/tests/test_fields.py
+++ b/snippets/base/tests/test_fields.py
@@ -1,18 +1,9 @@
-from django.core.exceptions import ValidationError
-
-from snippets.base.fields import validate_regex
+from snippets.base.admin.fields import JEXLChoiceField
 from snippets.base.tests import TestCase
 
 
-class RegexValidatorTests(TestCase):
-    def test_valid_string(self):
-        valid_string = 'foobar'
-        self.assertEqual(validate_regex(valid_string), valid_string)
-
-    def test_valid_regex(self):
-        valid_regex = '/\d+/'
-        self.assertEqual(validate_regex(valid_regex), valid_regex)
-
-    def test_invalid_regex(self):
-        bogus_regex = '/(?P\d+)/'
-        self.assertRaises(ValidationError, validate_regex, bogus_regex)
+class JEXLChoiceFieldTests(TestCase):
+    def test_to_jexl(self):
+        field = JEXLChoiceField('foo')
+        self.assertEqual(field.to_jexl(500), 'foo == 500')
+        self.assertEqual(field.to_jexl(''), None)

--- a/snippets/base/tests/test_forms.py
+++ b/snippets/base/tests/test_forms.py
@@ -6,10 +6,10 @@ from django.forms import ValidationError
 from mock import Mock, MagicMock, patch
 from pyquery import PyQuery as pq
 
-from snippets.base.forms import (IconWidget, SnippetAdminForm, SnippetNGAdminForm,
+from snippets.base.forms import (IconWidget, SnippetAdminForm, SnippetNGAdminForm, TargetAdminForm,
                                  TemplateDataWidget, TemplateSelect, UploadedFileAdminForm)
 from snippets.base.tests import (SnippetFactory, SnippetTemplateFactory,
-                                 SnippetTemplateVariableFactory, TestCase)
+                                 SnippetTemplateVariableFactory, TestCase, TargetFactory)
 
 
 class IconWidgetTests(TestCase):
@@ -298,3 +298,28 @@ class BaseSnippetAdminFormTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertTrue('You are not allowed to edit or publish on Release channel.' in
                         form.errors['__all__'][0])
+
+
+class TargetAdminFormTests(TestCase):
+    def setUp(self):
+        self.data = {
+            'name': 'foo-target',
+            'filtr_is_default_browser': 'true',
+        }
+
+    def test_set_initial_jexl(self):
+        data = self.data.copy()
+        instance = TargetFactory(jexl={'is_default_browser': 'false'})
+        form = TargetAdminForm(data, instance=instance)
+        self.assertEqual(form.fields['filtr_is_default_browser'].initial, 'false')
+
+    def test_save(self):
+        data = self.data.copy()
+        instance = TargetFactory()
+        form = TargetAdminForm(data, instance=instance)
+
+        self.assertTrue(form.is_valid())
+        form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.jexl_expr, 'isDefaultBrowser == true')
+        self.assertEqual(instance.jexl, {'is_default_browser': 'true'})

--- a/snippets/base/tests/test_forms.py
+++ b/snippets/base/tests/test_forms.py
@@ -309,7 +309,7 @@ class TargetAdminFormTests(TestCase):
 
     def test_set_initial_jexl(self):
         data = self.data.copy()
-        instance = TargetFactory(jexl={'is_default_browser': 'false'})
+        instance = TargetFactory(jexl={'filtr_is_default_browser': 'false'})
         form = TargetAdminForm(data, instance=instance)
         self.assertEqual(form.fields['filtr_is_default_browser'].initial, 'false')
 
@@ -322,4 +322,4 @@ class TargetAdminFormTests(TestCase):
         form.save()
         instance.refresh_from_db()
         self.assertEqual(instance.jexl_expr, 'isDefaultBrowser == true')
-        self.assertEqual(instance.jexl, {'is_default_browser': 'true'})
+        self.assertEqual(instance.jexl, {'filtr_is_default_browser': 'true'})

--- a/snippets/base/tests/test_validators.py
+++ b/snippets/base/tests/test_validators.py
@@ -4,7 +4,8 @@ from mock import patch
 from django.core.exceptions import ValidationError
 
 from snippets.base.validators import (validate_as_router_fluent_variables,
-                                      validate_xml_template, validate_xml_variables)
+                                      validate_xml_template, validate_xml_variables,
+                                      validate_regex)
 from snippets.base.tests import TestCase
 
 
@@ -53,3 +54,17 @@ class ASRouterFluentVariablesValidatorTests(TestCase):
     def test_invalid(self):
         data = json.dumps({'text': '<strong>Strong</strong> text.'})
         self.assertRaises(ValidationError, validate_as_router_fluent_variables, data)
+
+
+class RegexValidatorTests(TestCase):
+    def test_valid_string(self):
+        valid_string = 'foobar'
+        self.assertEqual(validate_regex(valid_string), valid_string)
+
+    def test_valid_regex(self):
+        valid_regex = '/\d+/'
+        self.assertEqual(validate_regex(valid_regex), valid_regex)
+
+    def test_invalid_regex(self):
+        bogus_regex = '/(?P\d+)/'
+        self.assertRaises(ValidationError, validate_regex, bogus_regex)

--- a/snippets/base/validators.py
+++ b/snippets/base/validators.py
@@ -1,3 +1,4 @@
+import re
 import json
 from io import StringIO
 
@@ -86,3 +87,12 @@ def validate_as_router_fluent_variables(data):
                      'Only {} are supported'.format(', '.join(ALLOWED_TAGS)))
         raise ValidationError(error_msg)
     return data
+
+
+def validate_regex(regex_str):
+    if regex_str.startswith('/'):
+        try:
+            re.compile(regex_str[1:-1])
+        except re.error as exp:
+            raise ValidationError(str(exp))
+    return regex_str


### PR DESCRIPTION
- Adds isDefaultBrowser JEXL Targeting
- Small refactor of fields to admin form and model fields.

The idea is that I'll create custom generic form fields that will output JEXL.  On form save the final JEXL expression will be calculated by joining on JEXL fields expressions. The expression will be added to AS payload as is. 

We also save individual JEXL field values in `Target.jexl` `DynamicField` to allow form initial value setting.

