### PR TITLE
[Fix #672] Add previousSessionEnd JEXL targeting.

### DIFF
--- a/snippets/base/admin/adminmodels.py
+++ b/snippets/base/admin/adminmodels.py
@@ -205,6 +205,7 @@ class TargetAdmin(admin.ModelAdmin):
                 'filtr_updates_autodownload_enabled',
                 'filtr_profile_age_created',
                 'filtr_firefox_version',
+                'filtr_previous_session_end',
                 'filtr_uses_firefox_sync',
                 'filtr_is_developer',
                 'filtr_current_search_engine',

--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -641,6 +641,19 @@ class TargetAdminForm(forms.ModelForm):
         label='Firefox Version',
         help_text='The version of the browser must fall between those two limits.'
     )
+    filtr_previous_session_end = fields.JEXLRangeField(
+        'previousSessionEnd',
+        # previousSessionEnd is in milliseconds. We first calculate the
+        # difference from currentDate and then we convert to week.
+        jexl={
+            'minimum': '((currentDate - previousSessionEnd) / 604800000) >= {value}',
+            'maximum': '((currentDate - previousSessionEnd) / 604800000) < {value}',
+        },
+        choices=PROFILE_AGE_CHOICES_AS,
+        required=False,
+        label='Previous Session End',
+        help_text='How many weeks since the last time Firefox was used?'
+    )
     filtr_uses_firefox_sync = fields.JEXLChoiceField(
         'usesFirefoxSync',
         choices=((None, "I don't care"),

--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -558,6 +558,7 @@ class Target(models.Model):
             'filtr_current_search_engine': str,
             'filtr_browser_addon': str,
             'filtr_total_bookmarks_count': str,
+            'filtr_previous_session_end': str,
         }
     )
     jexl_expr = models.TextField(blank=True, default='')


### PR DESCRIPTION
Waiting on `previousSessionEnd` to land so we can test.