### PR TITLE
[Issue #715] Handle Slack failures gracefully.

### DIFF
--- a/snippets/base/tests/test_slack.py
+++ b/snippets/base/tests/test_slack.py
@@ -19,5 +19,5 @@ class SendSlackTests(TestCase):
             slack._send_slack('foo')
         self.assertTrue(requests_mock.post.called)
         requests_mock.post.assert_called_with(
-            'https://example.com', data='foo',
+            'https://example.com', data='foo', timeout=4,
             headers={'Content-Type': 'application/json'})


### PR DESCRIPTION
When Slack goes down we still want to be able to publish snippets. Log the
exception and move on.