### PR TITLE
Set snippet.creator in form.save() to have full context on Slack.

### DIFF
--- a/snippets/base/admin/legacy.py
+++ b/snippets/base/admin/legacy.py
@@ -162,9 +162,6 @@ class SnippetAdmin(QuickEditAdmin, BaseSnippetAdmin):
         return form
 
     def save_model(self, request, obj, form, change):
-        # Only save creator for new Snippets.
-        if not change:
-            obj.creator = request.user
         statsd.incr('save.snippet')
         super(SnippetAdmin, self).save_model(request, obj, form, change)
 

--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -516,6 +516,9 @@ class SnippetAdminForm(BaseSnippetAdminForm):
     def save(self, *args, **kwargs):
         snippet = super(SnippetAdminForm, self).save(commit=False)
 
+        if not self.initial:
+            snippet.creator = self.current_user
+
         client_options = {}
         for key, value in self.cleaned_data.items():
             if key.startswith('client_option_'):
@@ -524,10 +527,10 @@ class SnippetAdminForm(BaseSnippetAdminForm):
         snippet.save()
 
         if 'ready_for_review' in self.changed_data and self.instance.ready_for_review is True:
-            send_slack('legacy_ready_for_review', self.instance)
+            send_slack('legacy_ready_for_review', snippet)
 
         if 'published' in self.changed_data and self.instance.published is True:
-            send_slack('legacy_published', self.instance)
+            send_slack('legacy_published', snippet)
 
         return snippet
 

--- a/snippets/base/templates/slack/legacy_ready_for_review.jinja.json
+++ b/snippets/base/templates/slack/legacy_ready_for_review.jinja.json
@@ -3,7 +3,7 @@
         "pretext": "Update on Snippet #{{ snippet.id }}",
         "title": "Snippet #{{ snippet.id }} is ready for review!",
         "title_link": "{{ snippet.get_admin_url() }}",
-        "text": "Snippet *#{{ snippet.id }}*: *{{ snippet.name }}* from {{ snippet.creator }} was just marked ready for review.",
+        "text": "Snippet *#{{ snippet.id }}*: *{{ snippet.name }}* by {{ snippet.creator }} was just marked ready for review.",
         "color": "#FF7F50"
   }]
 }


### PR DESCRIPTION
Slack messages didn't `snippet.creator` because it was being set in
`SnippetAdmin.save_model` which is called after `SnippetAdminForm.save`.

Setting snippet.creator in `SnippetAdminForm.save` solves this issue.