### PR TITLE
[Issue #911] Add `preview-` prefix to ID and Campaign when previewing.

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -694,10 +694,19 @@ class ASRSnippet(django_mysql.models.Model):
             'weight': self.weight,
             'content': data,
         }
-        if self.campaign:
-            rendered_snippet['campaign'] = self.campaign.slug
 
-        if not preview:
+        if preview:
+            rendered_snippet['id'] = 'preview-{}'.format(self.id)
+            # Always set do_not_autoblock when previewing.
+            rendered_snippet['content']['do_not_autoblock'] = True
+
+            if self.campaign:
+                rendered_snippet['campaign'] = 'preview-{}'.format(self.campaign.slug)
+
+        else:
+            if self.campaign:
+                rendered_snippet['campaign'] = self.campaign.slug
+
             rendered_snippet['targeting'] = ' && '.join(
                 [target.jexl_expr for target in self.targets.all().order_by('id')]
             )

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -371,15 +371,16 @@ class ASRSnippetTests(TestCase):
             targets=[TargetFactory(jexl_expr='foo == bar')])
         generated_result = snippet.render(preview=True)
         expected_result = {
-            'id': str(snippet.id),
+            'id': 'preview-{}'.format(snippet.id),
             'template': snippet.template.code_name,
             'template_version': snippet.template.version,
-            'campaign': snippet.campaign.slug,
+            'campaign': 'preview-{}'.format(snippet.campaign.slug),
             'weight': 100,
             'content': {
                 'text': 'snippet id {}'.format(snippet.id),
                 'foo': 'bar',
                 'links': {},
+                'do_not_autoblock': True,
             }
         }
         self.assertEqual(generated_result, expected_result)


### PR DESCRIPTION
AS triggers the blocking mechanism even when previewing snippets. Setting ID and
campaign to non-production identifiers will resolve the issue of production
Snippets not appearing to users who have interacted with them in preview.