### PR TITLE
 [Issue #757] Automatic localization of Template fields. 

### DIFF
--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -575,6 +575,27 @@ class SnippetTemplateVariableInlineFormset(forms.models.BaseInlineFormSet):
                 'There can be only one Main Text variable type per template')
 
 
+class AutoTranslatorWidget(forms.Select):
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        """For each key available in each Locale.translation JSON dictionary, create an
+        `translation-{key}` attribute. The attribute will be used by
+        `autoTranslatorWidget.js` to translate fields on Locale selection.
+
+        """
+        option = super().create_option(name, value, label, selected,
+                                       index, subindex=None, attrs=None)
+        if value:
+            option['attrs']['translations'] = models.Locale.objects.get(id=value).translations
+
+        return option
+
+    class Media:
+        js = [
+            'js/lib/jquery-3.3.1.min.js',
+            'js/autoTranslatorWidget.js',
+        ]
+
+
 class SimpleTemplateForm(forms.ModelForm):
 
     class Meta:
@@ -642,6 +663,9 @@ class ASRSnippetAdminForm(forms.ModelForm, PublishPermissionFormMixIn):
     class Meta:
         model = models.ASRSnippet
         exclude = ['creator', 'created', 'modified']
+        widgets = {
+            'locale': AutoTranslatorWidget,
+        }
 
     class Media:
         js = [

--- a/snippets/base/static/css/admin/ASRSnippetAdmin.css
+++ b/snippets/base/static/css/admin/ASRSnippetAdmin.css
@@ -42,3 +42,15 @@ td.field-description .vLargeTextField {
     width: 60em;
     height: 3em;
 }
+
+/* Make <input> Text and URLFields larger. */
+.vTextField, .vURLField {
+    width: 80%;
+}
+
+/* Do not allow adding, editing or deleting locales from the ASRSnippet admin to */
+/* avoid breaking the auto-localization feature */
+
+#change_id_locale, #add_id_locale, #delete_id_locale {
+    display: none;
+}

--- a/snippets/base/static/js/autoTranslatorWidget.js
+++ b/snippets/base/static/js/autoTranslatorWidget.js
@@ -1,0 +1,30 @@
+///
+//
+// Finds all template fields that match `translation-` attributes of the
+// selected #id_locale option and sets their value.
+//
+// All template fields start with `id_template_relation-` because Templates are
+// StackedInline objects.
+//
+// Gets triggered every time the user changes locale.
+///
+;$(function() {
+    'use strict';
+
+    function autoTranslate() {
+        let attributes = $('option:selected', '#id_locale')[0].attributes;
+        let translations = JSON.parse(attributes.translations.nodeValue);
+        Object.keys(translations).forEach(key => {
+            $("[id^='id_template_relation-']").each(function(i, obj) {
+                if (obj.name.endsWith('-' + key)) {
+                    $(obj).val(translations[key]);
+                }
+            });
+        });
+    }
+
+    // Translate content on locale select
+    $('#id_locale').change(function() {
+        autoTranslate();
+    });
+});


### PR DESCRIPTION
Requires #1045 

Example list of Locales with translations if needed for testing
```python
en = Locale.objects.get_or_create(name='English (All)', code='en', translations='{"block_button_text": "Remove this"}')
en_us = Locale.objects.get_or_create(name='English (American)', code='en-us', translations='{"block_button_text": "Remove this"}')
pt_br = Locale.objects.get_or_create(name='Portuguese (Brazilian)', code='pt-br', translations='{"block_button_text": "Remover este item"}')
pt_pt = Locale.objects.get_or_create(name='Portuguese (Portugal)', code='pt-pt')
zh_tw = Locale.objects.get_or_create(name='Chinese (Traditional)', code='zh-tw', translations='{"block_button_text": "移除這個"}')
zh_cn = Locale.objects.get_or_create(name='Chinese (Simplified)', code='zh-cn', translations='{"block_button_text": "删除它"}')
de = Locale.objects.get_or_create(name='German (All)', code='de', translations='{"block_button_text": "Entfernen"}')
es = Locale.objects.get_or_create(name='Spanish (All)', code='es', translations='{"block_button_text": "Quitar esto"}')
es_es = Locale.objects.get_or_create(name='Spanish (Spain)', code='es-es', translations='{"block_button_text": "Quitar esto"}')
es_latam = Locale.objects.get_or_create(name='Spanish (LatAm)', code='es-ar,es-cl,es-mx', translations='{"block_button_text": "Quitar esto"}')
ru = Locale.objects.get_or_create(name='Russian', code='ru', translations='{"block_button_text": "Удалить"}')
pl = Locale.objects.get_or_create(name='Polish', code='pl', translations='{"block_button_text": "Usuń to"}')
id = Locale.objects.get_or_create(name='Indonesian', code='id', translations='{"block_button_text": "Hilangkan ini"}')
fr = Locale.objects.get_or_create(name='French', code='fr', translations='{"block_button_text": "Supprimer"}')
it = Locale.objects.get_or_create(name='Italian', code='it', translations='{"block_button_text": "Nascondi questo messaggio"}')
```