### PR TITLE
[fix #1051] Clean up .gitlab-ci.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,16 +3,13 @@ dev:
     - meao
     - aws
   only:
-    - gitlab
+    - dev
     - master
   variables:
     NAMESPACE: snippets-dev
   script:
     - bin/build_images.sh
     - bin/push2dockerhub.sh
-    # no snippets-dev namespace in frankfurt currently
-    # uncomment when mozmeao/infra#1120 is closed
-    # - CLUSTER_NAME=frankfurt bin/update-config.sh
     - CLUSTER_NAME=oregon-b bin/update-config.sh
     
 
@@ -27,9 +24,6 @@ stage:
   script:
     - bin/build_images.sh
     - bin/push2dockerhub.sh
-    # no snippets-stage namespace in frankfurt currently
-    # uncomment when mozmeao/infra#1120 is closed
-    # - CLUSTER_NAME=frankfurt bin/update-config.sh
     - CLUSTER_NAME=oregon-b bin/update-config.sh
 
 
@@ -45,22 +39,4 @@ prod:
     - bin/build_images.sh
     - bin/push2dockerhub.sh
     - CLUSTER_NAME=frankfurt bin/update-config.sh
-    - CLUSTER_NAME=oregon-b bin/update-config.sh
-
-
-admin:
-  tags:
-    - meao
-    - aws
-  only:
-    - admin
-    - prod
-  variables:
-    NAMESPACE: snippets-admin
-  script:
-    - bin/build_images.sh
-    - bin/push2dockerhub.sh
-    # no snippets-admin namespace in frankfurt currently
-    # uncomment when mozmeao/infra#1120 is closed
-    # - CLUSTER_NAME=frankfurt bin/update-config.sh
     - CLUSTER_NAME=oregon-b bin/update-config.sh


### PR DESCRIPTION
- Remove admin job (no more admin namespace)
- Remove comments for dev/stage in frankfurt
- Rename 'gitlab' branch to 'dev' for dev job