### PR TITLE
[Fix #1065] Upgrade to Python 3.8 - Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3-slim-buster
 
 ARG DEVELOPMENT=false
 ENV LANG=C.UTF-8


### PR DESCRIPTION
Wait for docker python buster images to get released