### PR TITLE
[Fix #1080] Auto translate only visible fields.

### DIFF
--- a/snippets/base/static/js/autoTranslatorWidget.js
+++ b/snippets/base/static/js/autoTranslatorWidget.js
@@ -8,23 +8,25 @@
 //
 // Gets triggered every time the user changes locale.
 ///
-;$(function() {
-    'use strict';
-
-    function autoTranslate() {
-        let attributes = $('option:selected', '#id_locale')[0].attributes;
-        let translations = JSON.parse(attributes.translations.nodeValue);
-        Object.keys(translations).forEach(key => {
-            $("[id^='id_template_relation-']").each(function(i, obj) {
-                if (obj.name.endsWith('-' + key)) {
-                    $(obj).val(translations[key]);
-                }
-            });
-        });
+;function autoTranslate() {
+    let selected_locale = $('option:selected', '#id_locale')[0];
+    if (! selected_locale.value) {
+        return;
     }
-
-    // Translate content on locale select
-    $('#id_locale').change(function() {
-        autoTranslate();
+    let attributes = selected_locale.attributes;
+    let translations = JSON.parse(attributes.translations.nodeValue);
+    Object.keys(translations).forEach(key => {
+        $("[id^='id_template_relation-']").filter(":visible").each(function(i, obj) {
+            if (obj.name.endsWith('-' + key)) {
+                $(obj).val(translations[key]);
+            }
+        });
     });
+}
+
+$(function() {
+    // Translate content on locale select or template type select
+     $('#id_locale').change(function() {
+         autoTranslate();
+     });
 });

--- a/snippets/base/static/js/templateChooserWidget.js
+++ b/snippets/base/static/js/templateChooserWidget.js
@@ -7,6 +7,7 @@
         if (value) {
             $('.' + value).show();
         }
+        autoTranslate();
     }
 
     // Show correct template on load


### PR DESCRIPTION
The AutoTranslatorWidget was changing fields in hidden InlineTemplates, making
Django to consider the later `changed` and run validators against them. The
hidden Inline Templates are not supposed to be populated and thus they didn't
have values for the required fields which resulted in Django raising a cryptic
`Fix the errors below` messages, without errors being displayed (b/c the inlines
are hidden).

This commit fixes the issue by having the making AutoTranslatorWidget translate
only visible fields. For a complete solution we need to fix #1082 as well.