### PR TITLE
[Issue #1112] Redirect all requests to CDN / S3

### DIFF
--- a/snippets/base/tests/test_views.py
+++ b/snippets/base/tests/test_views.py
@@ -209,13 +209,6 @@ class FetchSnippetPregenBundleTests(TestCase):
         )
         self.assertEqual(response.url, expected_url)
 
-    def test_bundle_doesnt_exist(self):
-        with patch('snippets.base.views.default_storage.exists') as exists_mock:
-            exists_mock.return_value = False
-            response = views.fetch_snippet_pregen_bundle(self.request, **self.asrclient_kwargs)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b'{}')
-
 
 class FetchSnippetBundleTests(TestCase):
     def setUp(self):

--- a/snippets/base/views.py
+++ b/snippets/base/views.py
@@ -66,9 +66,6 @@ def fetch_snippet_pregen_bundle(request, **kwargs):
         f'{locale}/{distribution}.json'
     )
 
-    if not default_storage.exists(filename):
-        return HttpResponse(status=200, content='{}', content_type='application/json')
-
     full_url = urljoin(settings.CDN_URL or settings.SITE_URL,
                        urlparse(default_storage.url(filename)).path)
     # Remove AWS S3 parameters


### PR DESCRIPTION
Redirect all requests to CDN / S3 without checking first if the bundle exists on
S3.

CloudFront is configured to return a custom page (which is an empty JSON file)
when origins return 403 (Permission Denied). S3 bucket will return 403 -and not
404- when you request a file that doesn't exist because it disallows directory
listing.

This way we can return valid 404s from the Django app when needed and empty
bundles when we don't have a snippets for a channel / locale / distribution
combination, without spending time on I/O between the Django App and S3 or
hitting the cache too many times.