### PR TITLE
[Issue #855] Increase available Firefox versions.

### DIFF
--- a/snippets/base/admin/fields.py
+++ b/snippets/base/admin/fields.py
@@ -117,7 +117,7 @@ class JEXLFirefoxRangeField(JEXLRangeField):
         min_version = 64
         # Need to be able to dynamically change this, probably using
         # product_details. Issue #855
-        max_version = 74
+        max_version = 84
 
         choices = (
             [(None, 'No limit')] +


### PR DESCRIPTION
Increase to 84, which should get us to the end of 2020. By EOY we should have a
solution for this.