### PR TITLE
[Fix #1251] Use ADMIN_REDIRECT_URL for ASRSnippet preview link if available

### DIFF
--- a/snippets/base/models.py
+++ b/snippets/base/models.py
@@ -2093,7 +2093,7 @@ class ASRSnippet(models.Model):
         if dark:
             theme = 'dark'
         url = reverse('asr-preview', kwargs={'uuid': self.uuid})
-        full_url = urljoin(settings.SITE_URL, url)
+        full_url = urljoin(settings.ADMIN_REDIRECT_URL or settings.SITE_URL, url)
         return 'about:newtab?theme={}&endpoint={}'.format(theme, full_url)
 
     def get_admin_url(self, full=True):

--- a/snippets/base/tests/test_models.py
+++ b/snippets/base/tests/test_models.py
@@ -558,6 +558,14 @@ class ASRSnippetTests(TestCase):
         expected_result += reverse('asr-preview', kwargs={'uuid': snippet.uuid})
         self.assertEqual(snippet.get_preview_url(), expected_result)
 
+    @override_settings(SITE_URL='http://example.com',
+                       ADMIN_REDIRECT_URL='http://admin.example.com')
+    def test_get_preview_url_admin(self):
+        snippet = ASRSnippetFactory.create()
+        expected_result = 'about:newtab?theme=light&endpoint=http://admin.example.com'
+        expected_result += reverse('asr-preview', kwargs={'uuid': snippet.uuid})
+        self.assertEqual(snippet.get_preview_url(), expected_result)
+
     @override_settings(SITE_URL='http://example.com')
     def test_get_preview_url_dark(self):
         snippet = ASRSnippetFactory.create()


### PR DESCRIPTION
Only `snippets-admin.mozlla.org` is whitelisted on Fx for Activity Stream preview links. 