### PR TITLE
[Fix #1253] Show populated inline Template to users with view-only perms.

### DIFF
--- a/snippets/base/forms.py
+++ b/snippets/base/forms.py
@@ -615,7 +615,12 @@ class ASRSnippetAdminForm(forms.ModelForm):
             ('simple_below_search_snippet', 'Simple Below Search'),
         ),
         widget=TemplateChooserWidget,
-        required=False,
+        label='Template',
+    )
+    locale = forms.ModelChoiceField(
+        queryset=models.Locale.objects.all(),
+        empty_label='Select Locale',
+        widget=AutoTranslatorWidget,
     )
 
     def __init__(self, *args, **kwargs):
@@ -628,9 +633,6 @@ class ASRSnippetAdminForm(forms.ModelForm):
     class Meta:
         model = models.ASRSnippet
         exclude = ['creator', 'created', 'modified']
-        widgets = {
-            'locale': AutoTranslatorWidget,
-        }
 
     class Media:
         js = [

--- a/snippets/base/static/js/admin/templateChooserWidget.js
+++ b/snippets/base/static/js/admin/templateChooserWidget.js
@@ -6,12 +6,20 @@ document.addEventListener(
     'DOMContentLoaded',
     function() {
         function showTemplate() {
-            let value = django.jQuery('#id_template_chooser').val();
             django.jQuery('.inline-template').hide();
+
+            let value = django.jQuery('#id_template_chooser').val();
             if (value) {
                 django.jQuery('.' + value).show();
+                autoTranslate();
             }
-            autoTranslate();
+            // Template Chooser value is empty in two cases: a. When no template
+            // has been selected yet and b. when user has view-only permissions.
+            // In the later case there's a populated inline template which can
+            // be matched with the query bellow.
+            else {
+                django.jQuery('.inline-related.has_original').parent('.inline-template').show();
+            }
         }
 
         // Show correct template on load


### PR DESCRIPTION
Work around for the custom templates dropdown and the view-only permissions of the django admin.