### PR TITLE
[Fix #1399] Include total number of clients for Job.

### DIFF
--- a/snippets/base/admin/adminmodels.py
+++ b/snippets/base/admin/adminmodels.py
@@ -1221,6 +1221,8 @@ class JobAdmin(admin.ModelAdmin):
             adj_impressions=Sum('metrics__adj_impression'),
             clicks=Sum('metrics__click'),
             blocks=Sum('metrics__block'),
+            impressions_total_clients=Sum('metrics__impression_no_clients_total'),
+            adj_impressions_total_clients=Sum('metrics__adj_impression_no_clients_total'),
         )
         return queryset
 
@@ -1233,35 +1235,23 @@ class JobAdmin(admin.ModelAdmin):
     adj_impressions_humanized.short_description = 'Adjusted Impressions'
 
     def impressions_total_clients_humanized(self, obj):
-        try:
-            return intcomma(obj.metrics.first().impression_no_clients_total or 0)
-        except (AttributeError, ZeroDivisionError):
-            # Metrics don't exist yet for this Job.
-            return '-'
+        return intcomma(obj.impressions_total_clients or 0)
     impressions_total_clients_humanized.short_description = 'Total Unique Clients'
 
     def adj_impressions_total_clients_humanized(self, obj):
-        try:
-            return intcomma(obj.metrics.first().adj_impression_no_clients_total or 0)
-        except (AttributeError, ZeroDivisionError):
-            # Metrics don't exist yet for this Job.
-            return '-'
+        return intcomma(obj.adj_impressions_total_clients or 0)
     adj_impressions_total_clients_humanized.short_description = 'Adjusted Total Unique Clients'
 
     def impressions_per_client_humanized(self, obj):
-        try:
-            return f'{obj.impressions / obj.metrics.first().impression_no_clients_total:.2f}'
-        except (AttributeError, ZeroDivisionError):
-            # Metrics don't exist yet for this Job.
-            return '-'
+        if not obj.impressions_total_clients:
+            return 'N/A'
+        return f'{obj.impressions / obj.impressions_total_clients:.2f}'
     impressions_per_client_humanized.short_description = 'Impressions Per Client'
 
     def adj_impressions_per_client_humanized(self, obj):
-        try:
-            return f'{obj.adj_impressions/obj.metrics.first().adj_impression_no_clients_total:.2f}'
-        except (AttributeError, ZeroDivisionError):
-            # Metrics don't exist yet for this Job.
-            return '-'
+        if not obj.adj_impressions_total_clients:
+            return 'N/A'
+        return f'{obj.adj_impressions / obj.adj_impressions_total_clients:.2f}'
     adj_impressions_per_client_humanized.short_description = 'Adj Impressions Per Client'
 
     def clicks_humanized(self, obj):

--- a/snippets/base/etl.py
+++ b/snippets/base/etl.py
@@ -1,10 +1,9 @@
 import collections
 import json
-from datetime import datetime, timedelta
-from urllib.parse import urlencode
+from datetime import timedelta
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Sum, Q
 from django.db.transaction import atomic
 from redash_dynamic_query import RedashDynamicQuery
 
@@ -14,6 +13,7 @@ from snippets.base.models import CHANNELS, DailyImpressions, JobDailyPerformance
 REDASH_QUERY_IDS = {
     'bq-job': 72139,
     'bq-impressions': 72140,
+    'bq-total-clients': 72341,
 
     # Not currently used but kept here for reference.
     'redshift-job': 68135,
@@ -26,32 +26,22 @@ redash = RedashDynamicQuery(
     max_wait=settings.REDASH_MAX_WAIT)
 
 
-def redash_source_url(query_id_or_name, **params):
-    query_id = REDASH_QUERY_IDS.get(query_id_or_name, query_id_or_name)
-    url = f'{settings.REDASH_ENDPOINT}/queries/{query_id}/source'
-    if params:
-        url += '?' + urlencode({f'p_{key}_{query_id}': value
-                                for key, value in params.items()})
-    return url
-
-
-def redash_rows(query_name, date):
+def redash_rows(query_name, **params):
     query_id = REDASH_QUERY_IDS[query_name]
-    bind_data = {'date': str(date)}
-    result = redash.query(query_id, bind_data)
+    for k, v in params.items():
+        params[k] = str(v)
+    result = redash.query(query_id, params)
     return result['query_result']['data']['rows']
 
 
-def prosses_rows(rows, key='message_id'):
-    now = datetime.utcnow()
-
+def prosses_rows(rows, date, key='message_id'):
     # To fight Telemetry spam, process metrics for Jobs currently Published or
     # Completed the last 7 days.
     jobs = Job.objects.filter(
         # Still published
         Q(status=Job.PUBLISHED) |
-        # Or completed during the last 7 days
-        Q(completed_on__gte=now - timedelta(days=7))
+        # Or completed during the last 7 days from date
+        Q(completed_on__gte=date - timedelta(days=7))
     )
     job_ids = [str(x) for x in jobs.values_list('id', flat=True)]
     new_rows = []
@@ -173,8 +163,33 @@ def prosses_rows(rows, key='message_id'):
 
 
 def update_job_metrics(date):
-    rows = redash_rows('bq-job', date)
-    processed = prosses_rows(rows, key='message_id')
+    tomorrow = date + timedelta(days=1)
+    rows = redash_rows('bq-job', date=date)
+    # Find all finished Jobs with Impressions but no total clients
+    # that completed on `date`
+    query = (Job.objects
+             .filter(Q(status=Job.COMPLETED) | Q(status=Job.CANCELED))
+             .filter(completed_on__gte=f'{date.year}-{date.month}-{date.day} 00:00:00',
+                     completed_on__lt=f'{tomorrow.year}-{tomorrow.month}-{tomorrow.day} 00:00:00')
+             .annotate(no_clients_total=Sum('metrics__impression_no_clients_total'),
+                       impressions=Sum('metrics__impression'))
+             .filter(impressions__gt=0)
+             .filter(no_clients_total=0))
+
+    for job in query:
+        # If `publish_start` is more than 30 days earlier than completed on, we
+        # skip fetching total number of clients because that's scanning too much
+        # data and costs too much.
+        if (job.completed_on - job.publish_start).days > 30:
+            continue
+
+        rows += redash_rows(
+            'bq-total-clients',
+            message_id=job.id,
+            start_date=job.publish_start,
+            end_date=job.completed_on)
+
+    processed = prosses_rows(rows, date, key='message_id')
     with atomic():
         JobDailyPerformance.objects.filter(date=date).delete()
         for job, data in processed.items():
@@ -193,7 +208,7 @@ def update_impressions(date):
     Snippets by disgarding Impressions the lasted too few seconds.
 
     """
-    rows = redash_rows('bq-impressions', date)
+    rows = redash_rows('bq-impressions', date=date)
     details = []
     for row in rows:
         # Normalize channel name, based on what kind of snippets they get.

--- a/snippets/base/management/commands/fetch_daily_metrics.py
+++ b/snippets/base/management/commands/fetch_daily_metrics.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
         else:
             today = date.today()
             try:
-                fetched_dates = models.JobDailyPerformance.objects.values_list('date', flat=True)
+                fetched_dates = (models.JobDailyPerformance.objects
+                                 .values_list('date', flat=True)
+                                 .distinct())
             except models.JobDailyPerformance.DoesNotExist:
                 fetched_dates = []
 

--- a/snippets/base/tests/test_etl.py
+++ b/snippets/base/tests/test_etl.py
@@ -2,10 +2,9 @@ from datetime import date
 from unittest.mock import patch
 
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from snippets.base import etl
-from snippets.base.models import DailyImpressions, JobDailyPerformance
+from snippets.base.models import DailyImpressions, Job, JobDailyPerformance
 from snippets.base.tests import JobFactory
 
 
@@ -15,24 +14,25 @@ class TestRedashRows(TestCase):
     def test_base(self, query):
         d = date(2019, 12, 19)
         query_name, query_id = next(iter(etl.REDASH_QUERY_IDS.items()))
-        assert etl.redash_rows(query_name, d) == ['mock rows']
+        assert etl.redash_rows(query_name, date=d) == ['mock rows']
         bind_data = {'date': str(d)}
         query.assert_called_with(query_id, bind_data)
 
 
-class TestRedashSourceURL(TestCase):
-    @override_settings(REDASH_ENDPOINT='https://sql.telemetry.mozilla.org')
-    def test_base(self):
-        url = 'https://sql.telemetry.mozilla.org/queries/72139/source'
-        assert etl.redash_source_url('bq-job') == url
-        url += '?p_date_72139=2019-12-19'
-        assert etl.redash_source_url('bq-job', date='2019-12-19') == url
-
-
 class TestUpdateJobMetrics(TestCase):
     def test_base(self):
-        JobFactory.create(id=1000)
+        JobFactory.create(
+            id=1000,
+            status=Job.COMPLETED,
+            publish_start=date(2020, 1, 1),
+            completed_on=date(2020, 1, 10),
+        )
         JobFactory.create(id=2000)
+        JobDailyPerformance(
+            date=date(2020, 1, 9),
+            impression=100,
+            job=Job.objects.get(id=1000)
+        ).save()
 
         rows = [
             [
@@ -44,7 +44,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 5,
                     'no_clients': 2,
-                    'no_clients_total': 2,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '1000',
@@ -54,7 +54,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'ES',
                     'counts': 30,
                     'no_clients': 10,
-                    'no_clients_total': 17,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '1000',
@@ -64,7 +64,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'IT',
                     'counts': 50,
                     'no_clients': 20,
-                    'no_clients_total': 25,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '1000',
@@ -74,7 +74,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'UK',
                     'counts': 23,
                     'no_clients': 9,
-                    'no_clients_total': 12,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '1000',
@@ -84,7 +84,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'SW',
                     'counts': 27,
                     'no_clients': 50,
-                    'no_clients_total': 55,
+                    'no_clients_total': 0,
                 },
                 # To be discarded
                 {
@@ -95,7 +95,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 5,
                     'no_clients': 10,
-                    'no_clients_total': 15,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '1000',
@@ -105,7 +105,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 6,
                     'no_clients': 10,
-                    'no_clients_total': 15,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -116,7 +116,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 44,
                     'no_clients': 33,
-                    'no_clients_total': 36,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -126,7 +126,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'BG',
                     'counts': 3,
                     'no_clients': 10,
-                    'no_clients_total': 15,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -136,7 +136,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'AL',
                     'counts': 1,
                     'no_clients': 10,
-                    'no_clients_total': 15,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -147,7 +147,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 5,
                     'no_clients': 8,
-                    'no_clients_total': 8,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -158,7 +158,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'GR',
                     'counts': 3,
                     'no_clients': 4,
-                    'no_clients_total': 9,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -168,7 +168,7 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'ERROR',
                     'counts': 9,
                     'no_clients': 57,
-                    'no_clients_total': 553,
+                    'no_clients_total': 0,
                 },
                 {
                     'message_id': '2000',
@@ -178,28 +178,51 @@ class TestUpdateJobMetrics(TestCase):
                     'country_code': 'ERROR',
                     'counts': 1,
                     'no_clients': 1,
-                    'no_clients_total': 1,
+                    'no_clients_total': 0,
+                },
+            ],
+            [
+                {
+                    'message_id': '1000',
+                    'event_context': '',
+                    'event': 'IMPRESSION',
+                    'channel': 'release',
+                    'country_code': 'ES',
+                    'counts': 0,
+                    'no_clients': 0,
+                    'no_clients_total': 232,
+                },
+                {
+                    'message_id': '1000',
+                    'event_context': '',
+                    'event': 'IMPRESSION',
+                    'channel': 'release',
+                    'country_code': 'IT',
+                    'counts': 0,
+                    'no_clients': 0,
+                    'no_clients_total': 421,
                 },
             ],
         ]
 
         with patch('snippets.base.etl.redash_rows') as redash_rows_mock:
             redash_rows_mock.side_effect = rows
-            result = etl.update_job_metrics('2020-01-10')
+            result = etl.update_job_metrics(date(2020, 1, 10))
 
+        self.assertEqual(redash_rows_mock.call_count, 2)
         self.assertTrue(result)
-        self.assertEqual(JobDailyPerformance.objects.count(), 2)
+        self.assertEqual(JobDailyPerformance.objects.count(), 3)
 
-        jdp1 = JobDailyPerformance.objects.get(job_id=1000)
+        jdp1 = JobDailyPerformance.objects.filter(job_id=1000).order_by('-id')[0]
         self.assertEqual(jdp1.impression, 80)
         self.assertEqual(jdp1.impression_no_clients, 30)
-        self.assertEqual(jdp1.impression_no_clients_total, 42)
+        self.assertEqual(jdp1.impression_no_clients_total, 653)
         self.assertEqual(jdp1.click, 11)
         self.assertEqual(jdp1.click_no_clients, 12)
-        self.assertEqual(jdp1.click_no_clients_total, 17)
+        self.assertEqual(jdp1.click_no_clients_total, 0)
         self.assertEqual(jdp1.block, 50)
         self.assertEqual(jdp1.block_no_clients, 59)
-        self.assertEqual(jdp1.block_no_clients_total, 67)
+        self.assertEqual(jdp1.block_no_clients_total, 0)
         self.assertEqual(jdp1.dismiss, 0)
         self.assertEqual(jdp1.dismiss_no_clients, 0)
         self.assertEqual(jdp1.dismiss_no_clients_total, 0)
@@ -218,15 +241,15 @@ class TestUpdateJobMetrics(TestCase):
         self.assertEqual(len(jdp1.details), 5)
         for detail in [
                 {'event': 'click', 'counts': 11, 'channel': 'release',
-                 'country': 'GR', 'no_clients': 12, 'no_clients_total': 17},
+                 'country': 'GR', 'no_clients': 12, 'no_clients_total': 0},
                 {'event': 'impression', 'counts': 30, 'channel': 'release',
-                 'country': 'ES', 'no_clients': 10, 'no_clients_total': 17},
+                 'country': 'ES', 'no_clients': 10, 'no_clients_total': 232},
                 {'event': 'impression', 'counts': 50, 'channel': 'release',
-                 'country': 'IT', 'no_clients': 20, 'no_clients_total': 25},
+                 'country': 'IT', 'no_clients': 20, 'no_clients_total': 421},
                 {'event': 'block', 'counts': 23, 'channel': 'release',
-                 'country': 'UK', 'no_clients': 9, 'no_clients_total': 12},
+                 'country': 'UK', 'no_clients': 9, 'no_clients_total': 0},
                 {'event': 'block', 'counts': 27, 'channel': 'beta',
-                 'country': 'SW', 'no_clients': 50, 'no_clients_total': 55}
+                 'country': 'SW', 'no_clients': 50, 'no_clients_total': 0}
         ]:
             self.assertTrue(detail in jdp1.details)
 
@@ -236,41 +259,41 @@ class TestUpdateJobMetrics(TestCase):
         self.assertEqual(jdp2.impression_no_clients_total, 0)
         self.assertEqual(jdp2.click, 5)
         self.assertEqual(jdp2.click_no_clients, 8)
-        self.assertEqual(jdp2.click_no_clients_total, 8)
+        self.assertEqual(jdp2.click_no_clients_total, 0)
         self.assertEqual(jdp2.block, 0)
         self.assertEqual(jdp2.block_no_clients, 0)
         self.assertEqual(jdp2.block_no_clients_total, 0)
         self.assertEqual(jdp2.dismiss, 1)
         self.assertEqual(jdp2.dismiss_no_clients, 1)
-        self.assertEqual(jdp2.dismiss_no_clients_total, 1)
+        self.assertEqual(jdp2.dismiss_no_clients_total, 0)
         self.assertEqual(jdp2.go_to_scene2, 44)
         self.assertEqual(jdp2.go_to_scene2_no_clients, 33)
-        self.assertEqual(jdp2.go_to_scene2_no_clients_total, 36)
+        self.assertEqual(jdp2.go_to_scene2_no_clients_total, 0)
         self.assertEqual(jdp2.subscribe_error, 3)
         self.assertEqual(jdp2.subscribe_error_no_clients, 4)
-        self.assertEqual(jdp2.subscribe_error_no_clients_total, 9)
+        self.assertEqual(jdp2.subscribe_error_no_clients_total, 0)
         self.assertEqual(jdp2.subscribe_success, 9)
         self.assertEqual(jdp2.subscribe_success_no_clients, 57)
-        self.assertEqual(jdp2.subscribe_success_no_clients_total, 553)
+        self.assertEqual(jdp2.subscribe_success_no_clients_total, 0)
         self.assertEqual(jdp2.other_click, 4)
         self.assertEqual(jdp2.other_click_no_clients, 20)
-        self.assertEqual(jdp2.other_click_no_clients_total, 30)
+        self.assertEqual(jdp2.other_click_no_clients_total, 0)
         self.assertEqual(len(jdp2.details), 7)
         for detail in [
                 {'event': 'go_to_scene2', 'counts': 44, 'channel': 'release',
-                 'country': 'GR', 'no_clients': 33, 'no_clients_total': 36},
+                 'country': 'GR', 'no_clients': 33, 'no_clients_total': 0},
                 {'event': 'other_click', 'counts': 3, 'channel': 'release',
-                 'country': 'BG', 'no_clients': 10, 'no_clients_total': 15},
+                 'country': 'BG', 'no_clients': 10, 'no_clients_total': 0},
                 {'event': 'other_click', 'counts': 1, 'channel': 'release',
-                 'country': 'AL', 'no_clients': 10, 'no_clients_total': 15},
+                 'country': 'AL', 'no_clients': 10, 'no_clients_total': 0},
                 {'event': 'click', 'counts': 5, 'channel': 'release',
-                 'country': 'GR', 'no_clients': 8, 'no_clients_total': 8},
+                 'country': 'GR', 'no_clients': 8, 'no_clients_total': 0},
                 {'event': 'subscribe_error', 'counts': 3, 'channel': 'release',
-                 'country': 'GR', 'no_clients': 4, 'no_clients_total': 9},
+                 'country': 'GR', 'no_clients': 4, 'no_clients_total': 0},
                 {'event': 'subscribe_success', 'counts': 9, 'channel': 'release',
-                 'country': 'XX', 'no_clients': 57, 'no_clients_total': 553},
+                 'country': 'XX', 'no_clients': 57, 'no_clients_total': 0},
                 {'event': 'dismiss', 'counts': 1, 'channel': 'beta',
-                 'country': 'XX', 'no_clients': 1, 'no_clients_total': 1}
+                 'country': 'XX', 'no_clients': 1, 'no_clients_total': 0}
         ]:
             self.assertTrue(detail in jdp2.details)
 


### PR DESCRIPTION
Merge after #1412 

Fetches total number of clients for each Job when Job completes with a
special query and scans data from `publish_start` to `completed_on`.

This limits that amount of data scanned while it maintains
functionality. The only downside is that total number of clients that
interract with the Job (Snippet) is known well the Job finishes
publication instead of while the Job runs.

For Jobs that run for more than 30 days -usually  F100s- we don't
fetch client data to avoid scanning a too big dataset.