### PR TITLE
Further security updates 2022-01-13

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ boto3==1.16.63
 Brotli==1.0.9
 configparser==5.0.0
 contextlib2==0.6.0.post1
-Django==2.2.24
+Django==2.2.26
 dj-database-url==0.5.0
 django-admin-list-filter-dropdown==1.0.3
 django-allow-cidr==0.3.1

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-cache-url==3.0.0
 django-csp==3.7
 django-enforce-host==1.0.1
 django-extensions==3.1.5
-django-filter==2.2.0
+django-filter==2.4.0
 django-ical==1.8.0
 django-jinja==2.4.1
 django-modeladmin-reorder==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -201,9 +201,9 @@ django-extensions==3.1.5 \
     --hash=sha256:28e1e1bf49f0e00307ba574d645b0af3564c981a6dfc87209d48cb98f77d0b1a \
     --hash=sha256:9238b9e016bb0009d621e05cf56ea8ce5cce9b32e91ad2026996a7377ca28069
     # via -r requirements.in
-django-filter==2.2.0 \
-    --hash=sha256:558c727bce3ffa89c4a7a0b13bc8976745d63e5fd576b3a9a851650ef11c401b \
-    --hash=sha256:c3deb57f0dd7ff94d7dce52a047516822013e2b441bed472b722a317658cfd14
+django-filter==2.4.0 \
+    --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
+    --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1
     # via -r requirements.in
 django-ical==1.8.0 \
     --hash=sha256:0552d71595712129b78f104de175f6be6719c94b35f0e3b3679cf4e83938ec48 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -157,9 +157,9 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements.in
-django==2.2.24 \
-    --hash=sha256:3339ff0e03dee13045aef6ae7b523edff75b6d726adf7a7a48f53d5a501f7db7 \
-    --hash=sha256:f2084ceecff86b1e631c2cd4107d435daf4e12f1efcdf11061a73bf0b5e95f92
+django==2.2.26 \
+    --hash=sha256:85e62019366692f1d5afed946ca32fef34c8693edf342ac9d067d75d64faf0ac \
+    --hash=sha256:dfa537267d52c6243a62b32855a744ca83c37c70600aacffbfd98bc5d6d8518f
     # via
     #   -r requirements.in
     #   django-allow-cidr


### PR DESCRIPTION
Update dependencies. This covers:

* Bump django-filter from 2.2.0 to 2.4.0 (from PR #1559)
* Bump django from 2.2.24 to 2.2.26 (from PR #1560)