### PR TITLE
Revert "Bump django-filter from 2.2.0 to 2.4.0 (from PR #1559)"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-cache-url==3.0.0
 django-csp==3.7
 django-enforce-host==1.0.1
 django-extensions==3.1.5
-django-filter==2.4.0
+django-filter==2.2.0
 django-ical==1.8.0
 django-jinja==2.4.1
 django-modeladmin-reorder==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -201,9 +201,9 @@ django-extensions==3.1.5 \
     --hash=sha256:28e1e1bf49f0e00307ba574d645b0af3564c981a6dfc87209d48cb98f77d0b1a \
     --hash=sha256:9238b9e016bb0009d621e05cf56ea8ce5cce9b32e91ad2026996a7377ca28069
     # via -r requirements.in
-django-filter==2.4.0 \
-    --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
-    --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1
+django-filter==2.2.0 \
+    --hash=sha256:558c727bce3ffa89c4a7a0b13bc8976745d63e5fd576b3a9a851650ef11c401b \
+    --hash=sha256:c3deb57f0dd7ff94d7dce52a047516822013e2b441bed472b722a317658cfd14
     # via -r requirements.in
 django-ical==1.8.0 \
     --hash=sha256:0552d71595712129b78f104de175f6be6719c94b35f0e3b3679cf4e83938ec48 \


### PR DESCRIPTION
This reverts commit fe9b1329c78b612b343c08bcd43f8f42b2b3b650, unapplying the django-filter update