### PR TITLE
Dependency bumps - Django, New Relic, Sentry SDK

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ boto3==1.16.63
 Brotli==1.0.9
 configparser==5.0.0
 contextlib2==0.6.0.post1
-Django==2.2.26
+Django==2.2.27
 dj-database-url==0.5.0
 django-admin-list-filter-dropdown==1.0.3
 django-allow-cidr==0.3.1
@@ -30,13 +30,13 @@ gunicorn==19.9.0
 hiredis==1.1.0
 meinheld==1.0.2
 mozilla-django-oidc==1.2.4
-newrelic==5.0.2.126
+newrelic==7.4.0.172
 Pillow==9.0.0
 psycopg2==2.8.6
 pyjexl==0.3.0
 python-decouple==3.5
 redash-dynamic-query==1.0.4
-sentry-sdk==1.5.1
+sentry-sdk==1.5.4
 taggit-selectize==2.7.1
 urlwait==1.0
 whitenoise==5.2.0
@@ -46,6 +46,6 @@ importlib-metadata==3.3.0
 # dev
 Werkzeug==1.0.1
 flake8==3.8.4
-hashin==0.15.0
+hashin==0.17.0
 pip-tools==5.4.0
 pylint==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,9 +152,9 @@ cffi==1.15.0 \
     --hash=sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997 \
     --hash=sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796 \
     # via cryptography
-charset-normalizer==2.0.10 \
-    --hash=sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd \
-    --hash=sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455 \
+charset-normalizer==2.0.11 \
+    --hash=sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45 \
+    --hash=sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c \
     # via requests
 click==8.0.3 \
     --hash=sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3 \
@@ -248,9 +248,9 @@ django-ratelimit==3.0.1 \
     --hash=sha256:73223d860abd5c5d7b9a807fabb39a6220068129b514be8d78044b52607ab154 \
     --hash=sha256:857e797f23de948b204a31dba9d88aea3ce731b7a5d926d0240c772e19b5486f \
     # via -r requirements.in
-django-recurrence==1.10.3 \
-    --hash=sha256:715f681f6af029ff3a8d73c7b1460abd8cbc5d5a5001efcb127032e84d9cb963 \
-    --hash=sha256:9053b44b78b7fbfe3530673edfdd6d2f562105f8a192bc6a4b906a3df4f95f59 \
+django-recurrence==1.11.1 \
+    --hash=sha256:0c65f30872599b5813a9bab6952dada23c55894f28674490a753ada559f14bc5 \
+    --hash=sha256:9c89444e651a78c587f352c5f63eda48ab2f53996347b9fcdff2d248f4fcff70 \
     # via django-ical
 django-redis==4.11.0 \
     --hash=sha256:a5b1e3ffd3198735e6c529d9bdf38ca3fcb3155515249b98dc4d966b8ddf9d2b \
@@ -276,17 +276,17 @@ django-watchman==0.18.0 \
     --hash=sha256:3977ede248f6dce17a6936834efbf0b201376ea3c2aa98b8352935f3d09ed7e3 \
     --hash=sha256:9a2b8442d4791afc995dc3ba67ab7cf9461488f7aa07e0f4c0d2f4e52d2266d6 \
     # via -r requirements.in
-django==2.2.26 \
-    --hash=sha256:85e62019366692f1d5afed946ca32fef34c8693edf342ac9d067d75d64faf0ac \
-    --hash=sha256:dfa537267d52c6243a62b32855a744ca83c37c70600aacffbfd98bc5d6d8518f \
+django==2.2.27 \
+    --hash=sha256:1ee37046b0bf2b61e83b3a01d067323516ec3b6f2b17cd49b1326dd4ba9dc913 \
+    --hash=sha256:90763c764738586b11d7e1f44828032c153366e43ad7f782908193a1bb2d6d92 \
     # via -r requirements.in, django-allow-cidr, django-csp, django-extensions, django-filter, django-ical, django-jinja, django-modeladmin-reorder, django-mozilla-product-details, django-recurrence, django-redis, django-reversion, django-storages, django-taggit, django-taggit-helpers, django-watchman, mozilla-django-oidc
 factory-boy==3.2.1 \
     --hash=sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e \
     --hash=sha256:eb02a7dd1b577ef606b75a253b9818e6f9eaf996d94449c9d5ebb124f90dc795 \
     # via -r requirements.in
-faker==11.3.0 \
-    --hash=sha256:61f97034cea252b8426d81810afab2f3c27b584f2b4313400a0cc83a9b013ded \
-    --hash=sha256:adbe567e64da6a1097feacab699000e1ad16e17a6592a8f0ae1ee0b7fbf19887 \
+faker==12.2.0 \
+    --hash=sha256:2b6e3b10bbea344d2e29c902a9783e155e750ab69a83a220b3a04abb038392bf \
+    --hash=sha256:9d51eed0a0d93ca768101344237406ad63e6d86a3ba3ea44fd824629ef634fc5 \
     # via factory-boy
 flake8==3.8.4 \
     --hash=sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839 \
@@ -319,9 +319,9 @@ gunicorn==19.9.0 \
     --hash=sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471 \
     --hash=sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3 \
     # via -r requirements.in
-hashin==0.15.0 \
-    --hash=sha256:0ca4ce1507216b1fdeffb8cc009eb0561e81449668ffe436484f156ec27e6c22 \
-    --hash=sha256:316dff5c5f0bf98560682e92386fa4386a8ae402592f647d07bf7e450ea8f053 \
+hashin==0.17.0 \
+    --hash=sha256:4c03b3b1520a5117d8fdc26ae83c1267bc40da9925cd89b56b437bcb02bebb53 \
+    --hash=sha256:baa00fe209ee6800a7d09ffa3198b31d71ab1503730e7c172b7eccd01b6ec47e \
     # via -r requirements.in
 hiredis==1.1.0 \
     --hash=sha256:06a039208f83744a702279b894c8cf24c14fd63c59cd917dcde168b79eef0680 \
@@ -524,8 +524,22 @@ netaddr==0.8.0 \
     --hash=sha256:9666d0232c32d2656e5e5f8d735f58fd6c7457ce52fc21c98d45f2af78f990ac \
     --hash=sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243 \
     # via django-allow-cidr
-newrelic==5.0.2.126 \
-    --hash=sha256:9d6d3bf2e125410d485fd91279e1b0f50e8f0f5887284b345aed4ec81db33c0a \
+newrelic==7.4.0.172 \
+    --hash=sha256:059915807180f8f240afc7cc6bd243b354a41537f2c41924971d3eabae759b32 \
+    --hash=sha256:0b1d944a2b516f3917dbeb6d03269192cf420d562100237581a45a85b1d442b1 \
+    --hash=sha256:2f82df68486daa53e8781eae93a2353975f211602a5eb19d5046178b16759ad8 \
+    --hash=sha256:47442b6152c886f10fee5fd54cb700d9f702330df2c663276344af3fa5c3ec36 \
+    --hash=sha256:5815878b2edfc40c0544004b09c5ef740e5e344778b836669709b96f1d9090a0 \
+    --hash=sha256:5e8f487035a9d230899123c2390c57d8b3ebcb822de6e868cf6ac6b24944f079 \
+    --hash=sha256:74026271bf49591c0e919516ad5d3ba4728eb3d01f3587091bf8ef1e8f219238 \
+    --hash=sha256:973a3dc1b42b2c5340d97d1285cb25512b287ed87e503bb51ed02cef5a63e601 \
+    --hash=sha256:a5e91b08d2bed02087e5e53da51fe444135cc1c6c4fbd9d708791d731b055c35 \
+    --hash=sha256:a6de1dfb4605a0c975eebd1f5278b6e976c8a804f1ba286b3126ef83473e1c68 \
+    --hash=sha256:afd8c6613ba72e96a2a84bf53dfd3d084078e1f409c156cea8b1c18be152a9c9 \
+    --hash=sha256:cac47d1152ec588614d7eab5ee83a547239b0ea3a2abd65ab2faf9fe1369614f \
+    --hash=sha256:e7272aaff9efc4b6d9fd0224a836c8b953b84ac0dbcc107041d3bc1ef710b86a \
+    --hash=sha256:f42c760aad643b700c5d19600baf7d5c1928a036561d2c41ecf80ef7b5842ba3 \
+    --hash=sha256:f72f7d017309dc97b102dfb3826c16e9220e001ebe1ec32329a062b229ba734f \
     # via -r requirements.in
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
@@ -568,9 +582,9 @@ pillow==9.0.0 \
     --hash=sha256:ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e \
     --hash=sha256:fd0e5062f11cb3e730450a7d9f323f4051b532781026395c4323b8ad055523c4 \
     # via -r requirements.in
-pip-api==0.0.26 \
-    --hash=sha256:b24e94e5d5d3f161a2db49653798e6a4c1f0ed6b379e511b45a8fa57c185d711 \
-    --hash=sha256:d1266be311f1cd1ddd0d501e99275c7f6ff1fd0ec6db46d521f56e747d9286e5 \
+pip-api==0.0.27 \
+    --hash=sha256:354825f2fa89b9b1c56e943be32823c09590e13055a57af5590456ff7d6524bd \
+    --hash=sha256:da0a10870b9105bc7ff7f347793db885c5c30102032de9112a6118b7af645478 \
     # via hashin
 pip-tools==5.4.0 \
     --hash=sha256:a4d3990df2d65961af8b41dacc242e600fdc8a65a2e155ed3d2fc18a5c209f20 \
@@ -613,9 +627,9 @@ pylint==2.6.0 \
     --hash=sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210 \
     --hash=sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f \
     # via -r requirements.in
-pyopenssl==21.0.0 \
-    --hash=sha256:5e2d8c5e46d0d865ae933bef5230090bdaf5506281e9eec60fa250ee80600cb3 \
-    --hash=sha256:8935bd4920ab9abfebb07c41a4f58296407ed77f04bd1a92914044b848ba1ed6 \
+pyopenssl==22.0.0 \
+    --hash=sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf \
+    --hash=sha256:ea252b38c87425b64116f808355e8da644ef9b07e429398bfece610f893ee2e0 \
     # via josepy
 pyparsing==3.0.7 \
     --hash=sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea \
@@ -635,13 +649,13 @@ python-decouple==3.5 \
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
     --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326 \
-    # via apscheduler, django, django-recurrence, icalendar, tzlocal
+    # via apscheduler, django, icalendar, tzlocal
 redash-dynamic-query==1.0.4 \
     --hash=sha256:d2756ad2f7fd21f33cbf8c751ec3fccaf9ad350a27b968cd56b3d1783650b5f9 \
     # via -r requirements.in
-redis==4.1.1 \
-    --hash=sha256:07420a3fbedd8e012c31d4fadac943fb81568946da202c5a5bc237774e5280a0 \
-    --hash=sha256:bc97d18938ca18d66737d0ef88584a2073069589e4026813cfba9ad6df9a9f40 \
+redis==4.1.3 \
+    --hash=sha256:267e89e476eb684517584e8988f1e5d755f483a368c133020c4c40e8b676bc5d \
+    --hash=sha256:f2715caad9f0e8c6ff8df46d3c4c9022a3929001f530f66b62747554d3067068 \
     # via django-redis
 requests==2.27.1 \
     --hash=sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61 \
@@ -651,14 +665,14 @@ s3transfer==0.3.7 \
     --hash=sha256:35627b86af8ff97e7ac27975fe0a98a312814b46c6333d8a6b889627bcd80994 \
     --hash=sha256:efa5bd92a897b6a8d5c1383828dca3d52d0790e0756d49740563a3fb6ed03246 \
     # via boto3
-sentry-sdk==1.5.1 \
-    --hash=sha256:2a1757d6611e4bec7d672c2b7ef45afef79fed201d064f53994753303944f5a8 \
-    --hash=sha256:e4cb107e305b2c1b919414775fa73a9997f996447417d22b98e7610ded1e9eb5 \
+sentry-sdk==1.5.4 \
+    --hash=sha256:4fc7960a82c95d906a0514cf4d9aacba1743eb9863a5b7c2a01c525a7d9b21e6 \
+    --hash=sha256:f7e54567937ebcbe938c4df1075ec891587faeb7c74184b88cf2894e47c86116 \
     # via -r requirements.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254 \
-    # via apscheduler, babis, bleach, mozilla-django-oidc, parsimonious, pip-tools, pyopenssl, python-dateutil
+    # via apscheduler, babis, bleach, mozilla-django-oidc, parsimonious, pip-tools, python-dateutil
 sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
     --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d \
@@ -666,10 +680,6 @@ sqlparse==0.4.2 \
 taggit-selectize==2.7.1 \
     --hash=sha256:5c45faf1bb58176d3392446951ae0c0dc53f093deaf7cff2597769207c5f5a61 \
     # via -r requirements.in
-text-unidecode==1.3 \
-    --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
-    --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93 \
-    # via faker
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f \


### PR DESCRIPTION
Django was a security patch, and did the others while in the area as low-risk
quick wins